### PR TITLE
v2.3 + v2.4: 中文名纠错 + 数据缺口 agent 接管 + 大佬抓作业放全 + 6 维定性分析方法论

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,15 @@
+# UZI-Skill · 本地环境变量（可选）
+# 把本文件复制为 .env 并填入你自己的值：
+#   cp .env.example .env
+#   # 然后编辑 .env 填 key
+
+# ─── 东财妙想 Skills Hub API（推荐配置）──────────────────────
+# 设置后 UZI-Skill 会优先使用官方 NLP API 做：
+#   1. 中文名纠错（"北部港湾" 自动识别为 "北部湾港"）
+#   2. 股票行情快照（稳定性远高于爬 push2.eastmoney.com）
+# 获取 key（免费）: https://dl.dfcfs.com/m/itc4
+MX_APIKEY=
+
+# ─── 其他可选 ─────────────────────────────────────────────
+# STOCK_NO_CACHE=1        # 禁用所有 API 缓存，强制重新拉取
+# UZI_NO_AUTO_OPEN=1      # 分析完不自动打开浏览器

--- a/.gitignore
+++ b/.gitignore
@@ -29,8 +29,10 @@ desktop.ini
 # Debug / temp scripts (per-ticket, not for distribution)
 skills/deep-analysis/scripts/_*.py
 
-# Env
+# Env (v2.3: 存放 MX_APIKEY 等敏感凭据，绝不 commit)
 .env
 .env.local
+.env.*.local
+*.local.env
 *.key
 docs/screenshots/full-page.png

--- a/README.md
+++ b/README.md
@@ -264,6 +264,33 @@ Bull ¥26.95 / Base ¥20.73 / Bear ¥14.51，每个情景有概率和假设。
 
 多层 fallback 链 — 一个源挂了自动切下一个。
 
+### 🔑 可选：东方财富妙想 Skills API（v2.3 新增）
+
+2026 年 `push2.eastmoney.com` 在大陆网络经常被反爬拦截。若设置
+`MX_APIKEY`，UZI-Skill 会优先走官方 NLP API：
+
+- **中文名纠错**："北部港湾" → 自动识别为 "北部湾港(000582.SZ)"
+- **行情快照**：绕过 push2 直接拿到最新价/市值/PE/PB/行业
+
+配置：
+```bash
+cp .env.example .env
+# 编辑 .env 填入 MX_APIKEY（免费申领：https://dl.dfcfs.com/m/itc4）
+```
+
+无 key 时全部回退到 XueQiu/akshare 链，现有用户零感知。
+
+### 🚨 数据缺口怎么处理（v2.3）
+
+若某些字段脚本拿不到（网络限制 / 新股 / 停牌），pipeline **不会塞默认值糊弄**：
+
+1. 生成 `_data_gaps.json` 列出每个缺口的建议恢复动作（浏览器 / MX / WebSearch / 推导）
+2. Agent 按 [HARD-GATE-DATAGAPS](skills/deep-analysis/SKILL.md) 逐条尝试补齐
+3. 真的补不到 → 在 `agent_analysis.json` 里 `data_gap_acknowledged` 显式承认
+4. HTML 报告顶部显示橙色 banner + 相关字段显示 "—" 并划线
+
+这样你永远能分辨"这只股真的不适合买" vs "只是数据没拿到"。
+
 ---
 
 ## 📁 项目结构

--- a/run.py
+++ b/run.py
@@ -43,6 +43,34 @@ sys.path.insert(0, str(SCRIPTS_DIR))
 os.chdir(str(SCRIPTS_DIR))
 
 
+# ─── .env 加载（v2.3，零依赖，不覆盖已存在的 shell env）──
+def _load_dotenv():
+    """Load KEY=VALUE pairs from $REPO/.env into os.environ.
+
+    Deliberately simple (no quoting games, no variable interpolation) — enough
+    to pick up MX_APIKEY and friends. Existing shell env vars take precedence,
+    so `export MX_APIKEY=...` always wins.
+    """
+    env_path = ROOT_DIR / ".env"
+    if not env_path.exists():
+        return
+    try:
+        for line in env_path.read_text(encoding="utf-8").splitlines():
+            line = line.strip()
+            if not line or line.startswith("#") or "=" not in line:
+                continue
+            key, _, val = line.partition("=")
+            key = key.strip()
+            val = val.strip().strip("'\"")  # strip optional quotes
+            if key and key not in os.environ:
+                os.environ[key] = val
+    except Exception as e:
+        print(f"⚠️  .env 读取失败（忽略）: {e}")
+
+
+_load_dotenv()
+
+
 def detect_environment() -> dict:
     """检测当前运行环境。"""
     env = {
@@ -171,7 +199,14 @@ def main():
                         help="不自动打开浏览器")
     parser.add_argument("--port", type=int, default=8976,
                         help="HTTP 服务端口 (默认 8976)")
+    parser.add_argument("--force-name", metavar="CODE",
+                        help="绕过中文名纠错直接使用指定代码 (如 --force-name 000582.SZ)")
     args = parser.parse_args()
+
+    # v2.3 · --force-name 直接覆盖
+    if args.force_name:
+        print(f"   [force-name] {args.ticker} → {args.force_name}")
+        args.ticker = args.force_name
 
     env = detect_environment()
 
@@ -190,10 +225,61 @@ def main():
     # 检查依赖
     check_dependencies()
 
+    # v2.3 · MX API 状态提示
+    if os.environ.get("MX_APIKEY"):
+        print(f"🔑 MX_APIKEY 已设置 · 将优先使用东财妙想 API")
+    else:
+        print(f"ℹ️  未设置 MX_APIKEY · 走默认 akshare/xueqiu 链（可在 .env 里配置）")
+
     # 运行分析（抑制 run_real_test 内部的自动开浏览器）
     os.environ["UZI_NO_AUTO_OPEN"] = "1"
-    from run_real_test import main as run_analysis
-    run_analysis(args.ticker)
+    from run_real_test import main as run_analysis, stage1 as _stage1, stage2 as _stage2
+
+    # v2.3 · 先过 stage1，捕获中文名解析失败场景，不静默跑出空报告
+    from lib.market_router import is_chinese_name
+    if is_chinese_name(args.ticker) and not args.force_name:
+        stage1_result = _stage1(args.ticker)
+        if isinstance(stage1_result, dict) and stage1_result.get("status") == "name_not_resolved":
+            cands = stage1_result.get("candidates", [])
+            print(f"\n{'━' * 50}")
+            print(f"❌ 无法确定股票: {args.ticker!r}")
+            if not cands:
+                print(f"   没有找到相似候选。请用准确的股票代码（如 600519.SH）重试。")
+                sys.exit(2)
+            print(f"   找到 {len(cands)} 个候选:")
+            for i, c in enumerate(cands[:5], 1):
+                print(f"     [{i}] {c['name']:<12s}  {c['code']}   (距离 {c.get('distance', '?')})")
+            # 交互式确认（若 TTY）— agent/CI 环境直接退出让上层决策
+            if sys.stdin.isatty():
+                try:
+                    choice = input("\n   选择候选编号（1-5），或直接回车取消: ").strip()
+                    if choice and choice.isdigit() and 1 <= int(choice) <= len(cands):
+                        picked = cands[int(choice) - 1]
+                        print(f"   ✓ 使用 {picked['name']} ({picked['code']})")
+                        args.ticker = picked["code"]
+                        # 用选定代码重跑 stage1 然后 stage2
+                        _stage1(args.ticker)
+                        _stage2(args.ticker)
+                    else:
+                        print("   已取消。")
+                        sys.exit(2)
+                except (EOFError, KeyboardInterrupt):
+                    print("\n   已取消。")
+                    sys.exit(2)
+            else:
+                # Non-interactive: surface structured error and exit 2
+                import json as _json
+                print(_json.dumps(stage1_result, ensure_ascii=False, indent=2))
+                sys.exit(2)
+        else:
+            # stage1 已经成功跑完 — 用它返回的 resolved ticker 跑 stage2（cache 是以解析后代码命名的）
+            resolved = stage1_result.get("ticker") if isinstance(stage1_result, dict) else None
+            _stage2(resolved or args.ticker)
+            # 对齐 args.ticker 以便后续 report_dir 查找
+            if resolved:
+                args.ticker = resolved
+    else:
+        run_analysis(args.ticker)
 
     # 找到生成的报告
     from datetime import datetime

--- a/skills/deep-analysis/SKILL.md
+++ b/skills/deep-analysis/SKILL.md
@@ -46,6 +46,41 @@ description: 个股深度分析的核心工作流。当用户要求"深度分析
 唯一例外：用户原话含"自动选最相近的"或明确说"就是 Top1" — 此时可以不问
 </HARD-GATE>
 
+### ⛔ HARD-GATE-QUALITATIVE · 6 维定性维度必须 agent 深度分析（v2.4）
+
+<HARD-GATE>
+在 stage2 之前，**3_macro / 7_industry / 8_materials / 9_futures / 13_policy / 15_events**
+这 6 个定性维度必须由 agent 做跨域联想 + 多源抓取后产出结构化分析，不得直接用爬虫片段
+拼到 dim_commentary 里。
+
+**强制流程**（详见 `references/task2.5-qualitative-deep-dive.md`）：
+
+1. 读 `task2.5-qualitative-deep-dive.md` — 这是详尽操作手册（6 维每维 4-7 问、6 条跨域
+   因果链、各维度浏览器 URL 模板、输出 schema）
+2. **Spawn 3 个并行 sub-agent**（Agent tool · subagent_type=general-purpose）：
+   - **A · Macro-Policy**：3_macro + 13_policy
+   - **B · Industry-Events**：7_industry + 15_events
+   - **C · Cost-Transmission**：8_materials + 9_futures
+3. 每个 sub-agent 必须使用：
+   - `WebSearch`（精确到公司名 + 代码 + 行业关键词）
+   - `Chrome/Playwright MCP`（打开 cninfo/xueqiu/gov.cn/证监会/工信部 抓原文）
+   - `mx_api.MXClient`（若 `MX_APIKEY` 已设置）
+4. 合并三个 sub-agent 的输出，写入 `.cache/{ticker}/agent_analysis.json` 的
+   `qualitative_deep_dive` 字段（schema 见 task2.5 第 5 节）
+5. **质量硬红线**：
+   - 每维 `evidence` ≥ 2 条且每条必有具体 URL
+   - 6 维合计 ≥ 3 条 `associations`（跨域因果链，对应 task2.5 第 3 节的 6 条里选 3）
+   - `dim_commentary` 每句必须 cite `qualitative_deep_dive.*.evidence[*].url` 之一
+
+**绝对禁止**：
+- 单 agent 串行覆盖 6 维（必须 3 个并行 sub-agent）
+- 把 raw_data 的爬虫片段直接粘贴当 commentary
+- evidence 为空、url 空字符串、或仅用"值得关注/基本面良好/需要观察"这三个废话词
+- 跳过 task2.5 的问题清单自由发挥
+
+用户要求原话："不能只靠数据爬取，必须要 agent 介入高强度分析 + 多 agent 操作一定要加入进去"
+</HARD-GATE>
+
 ### ⛔ HARD-GATE-DATAGAPS · 数据缺口 agent 必须接管（v2.3）
 
 <HARD-GATE>

--- a/skills/deep-analysis/SKILL.md
+++ b/skills/deep-analysis/SKILL.md
@@ -31,6 +31,48 @@ description: 个股深度分析的核心工作流。当用户要求"深度分析
 5. **矛盾必须呈现，不准和稀泥**：DCF 与 Comps 结论冲突时，**把冲突写进报告**；51 评委分歧大时，**强调分歧本身是信息**。
 6. **Task 1 必须并行执行**（4 个子 agent / wave），串行跑 22 个 fetcher 直接扣分。
 
+### ⛔ HARD-GATE-NAME · 股票名纠错（v2.3）
+
+<HARD-GATE>
+若 `stage1()` 返回 `{"status": "name_not_resolved", "candidates": [...]}`（或生成了
+`.cache/{input}/_resolve_error.json`），你**绝不能**假装猜到正确股票继续跑。
+
+你必须：
+1. 读 `_resolve_error.json` 拿到 `user_input` 和候选列表
+2. 用 `AskUserQuestion` 把 Top 3-5 候选呈现给用户（"你是不是想输入 X？"）
+3. 用户确认后，用**选中的代码**（如 `000582.SZ`）而不是原始名字重跑 `stage1()`
+4. 若候选为空（真查不到），告知用户并建议直接输入代码
+
+唯一例外：用户原话含"自动选最相近的"或明确说"就是 Top1" — 此时可以不问
+</HARD-GATE>
+
+### ⛔ HARD-GATE-DATAGAPS · 数据缺口 agent 必须接管（v2.3）
+
+<HARD-GATE>
+若 `.cache/{ticker}/_data_gaps.json` 存在且 `tasks` 非空，你**必须**在调用
+`stage2()` 之前逐条尝试补齐，按优先级：
+
+1. **浏览器自动化**（最稳）— 用 Chrome/Playwright MCP 打开 xueqiu.com/S/{code}
+   或 quote.eastmoney.com/{code}.html 手动抓字段。特别是 `push2.eastmoney.com`
+   被反爬时，浏览器是唯一能拿到实时行情的通道。
+2. **MX 妙想 API**（若 `MX_APIKEY` 已设置）— 用 `mx_api.MXClient.query()`
+3. **WebSearch** 精确到代码（不要只搜公司名 — 会命中同名无关内容）
+4. **逻辑推导** — 从已有数据算（净利率 = 净利润 / 营收；PE = 市值/净利润）
+
+**仍然拿不到的字段**：在 `agent_analysis.json` 里写：
+```json
+"data_gap_acknowledged": {
+  "0_basic.industry": "已尝试 xueqiu/eastmoney/ws，均返回空 — 可能是新股或暂停上市",
+  "4_peers": "该细分行业上市公司不足 3 家，真的找不到同行"
+}
+```
+stage2 会把这些字段标为"已确认拿不到"，HTML 报告显示划线 chip + "—"而不是假数据。
+
+**绝对禁止**：在补不到数据时用默认值（0 / 空字符串 / "—"）当真实数据用、让规则引擎
+对空 features 打分（会产生"没数据的幻觉"，像之前"北部港湾"那次 panel 35.4% 共识
+其实是空 features 导致的全 fail_msg）。
+</HARD-GATE>
+
 ## 📊 进度条规范
 
 每完成一个 Task，输出一行进度条（20 字符固定宽度）：

--- a/skills/deep-analysis/assets/report-template.html
+++ b/skills/deep-analysis/assets/report-template.html
@@ -1284,6 +1284,92 @@ body::after {
   grid-template-columns: repeat(auto-fill, minmax(340px, 1fr));
   gap: 16px;
 }
+
+/* ═══ v2.4 · 紧凑行列表（展开后排名 7+ 的基金显示） ═══ */
+.fund-compact-list {
+  margin-top: 16px;
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  overflow: hidden;
+  max-height: 600px;
+  overflow-y: auto;
+  background: var(--bg-card);
+}
+.fund-compact-head,
+.fund-compact-row {
+  display: grid;
+  grid-template-columns: 44px 40px minmax(0, 2fr) 96px 100px 32px;
+  align-items: center;
+  gap: 12px;
+  padding: 10px 16px;
+  border-bottom: 1px solid var(--border);
+}
+.fund-compact-head {
+  background: var(--bg-tinted);
+  font-family: 'Space Grotesk', sans-serif;
+  font-size: 11px;
+  letter-spacing: .1em;
+  text-transform: uppercase;
+  color: var(--text-dim);
+  position: sticky;
+  top: 0;
+  z-index: 1;
+}
+.fund-compact-row { transition: background .15s ease; }
+.fund-compact-row:hover { background: var(--gold-tint); }
+.fund-compact-row:last-child { border-bottom: none; }
+.fc-rank {
+  width: 36px; height: 28px;
+  display: inline-flex; align-items: center; justify-content: center;
+  border-radius: 6px;
+  font-family: 'Fira Code', monospace;
+  font-size: 12px;
+  font-weight: 700;
+}
+.fc-avatar {
+  width: 32px; height: 32px;
+  border-radius: 6px;
+  border: 1px solid var(--border);
+  image-rendering: pixelated;
+  background: #fff;
+  flex-shrink: 0;
+}
+.fc-avatar-ph {
+  display: inline-flex; align-items: center; justify-content: center;
+  font-family: 'Fira Sans', sans-serif;
+  font-size: 14px; font-weight: 800;
+  color: var(--neon-gold);
+  background: var(--gold-tint);
+}
+.fc-info { min-width: 0; overflow: hidden; }
+.fc-name {
+  font-family: 'Fira Sans', sans-serif;
+  font-weight: 700; font-size: 13px;
+  color: var(--text-bright);
+  white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+}
+.fc-fund {
+  font-family: 'Fira Sans', sans-serif;
+  font-size: 11px;
+  color: var(--text-dim);
+  white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+}
+.fc-return, .fc-rank-pct {
+  font-family: 'Fira Code', monospace;
+  font-size: 13px;
+  font-weight: 700;
+  text-align: right;
+}
+.fc-link {
+  display: inline-flex; align-items: center; justify-content: center;
+  width: 28px; height: 28px;
+  border-radius: 6px;
+  text-decoration: none;
+  color: var(--neon-cyan);
+  font-size: 18px;
+  transition: all .15s ease;
+}
+.fc-link:hover { background: var(--gold-tint); color: var(--neon-gold); transform: translateX(2px); }
 .fund-card {
   background: var(--bg-card);
   border: 1px solid var(--border);

--- a/skills/deep-analysis/assets/report-template.html
+++ b/skills/deep-analysis/assets/report-template.html
@@ -123,6 +123,36 @@ body::after {
 .market-badge.open { background: var(--bull-tint); color: var(--bull-green); border: 1px solid var(--bull-green); }
 .market-badge.closed { background: var(--bg-tinted); color: var(--text-dim); border: 1px solid var(--border); }
 
+/* ═══════════════ DATA QUALITY BANNER · v2.3 ═══════════════ */
+.data-gap-banner {
+  margin: 16px 0 24px;
+  padding: 16px 20px;
+  background: linear-gradient(135deg, rgba(245, 158, 11, 0.12), rgba(245, 158, 11, 0.04));
+  border: 1px solid rgba(245, 158, 11, 0.45);
+  border-left: 4px solid #f59e0b;
+  border-radius: 8px;
+  display: flex;
+  gap: 16px;
+  align-items: flex-start;
+}
+.data-gap-banner .icon { font-size: 22px; line-height: 1; flex-shrink: 0; }
+.data-gap-banner .body { flex: 1; }
+.data-gap-banner .title { font-family: 'Space Grotesk', sans-serif; font-weight: 700; font-size: 15px; color: #f59e0b; margin-bottom: 4px; letter-spacing: .04em; }
+.data-gap-banner .subtitle { font-size: 13px; color: var(--text-bright); line-height: 1.6; }
+.data-gap-banner .subtitle strong { color: #f59e0b; }
+.data-gap-banner .list { margin-top: 10px; display: flex; flex-wrap: wrap; gap: 6px; }
+.data-gap-banner .chip {
+  font-family: 'Fira Code', monospace;
+  font-size: 11px;
+  padding: 3px 10px;
+  background: rgba(245, 158, 11, 0.15);
+  color: #fbbf24;
+  border: 1px solid rgba(245, 158, 11, 0.35);
+  border-radius: 999px;
+}
+.data-gap-banner .chip.ack { background: rgba(148, 163, 184, 0.15); color: var(--text-dim); border-color: var(--border); text-decoration: line-through; }
+.data-gap-banner .hint { margin-top: 8px; font-size: 11px; color: var(--text-dim); letter-spacing: .05em; }
+
 /* ═══════════════ BENTO HERO ═══════════════ */
 .bento-hero {
   display: grid;
@@ -2128,6 +2158,9 @@ footer strong { color: var(--text-dim); }
       <span>· DATA @ {{DATA_FETCHED_AT}} · v0.1.0</span>
     </div>
   </div>
+
+  <!-- ─── DATA QUALITY BANNER · v2.3 (only rendered when _data_gaps.json exists) ─── -->
+  <!-- INJECT_DATA_GAP_BANNER -->
 
   <!-- ─── BENTO HERO ─── -->
   <div class="bento-hero">

--- a/skills/deep-analysis/references/task2.5-qualitative-deep-dive.md
+++ b/skills/deep-analysis/references/task2.5-qualitative-deep-dive.md
@@ -1,0 +1,407 @@
+# Task 2.5 · 6 维定性深度分析方法论（v2.4）
+
+> 本文档是 [SKILL.md · HARD-GATE-QUALITATIVE](../SKILL.md) 的详细操作手册。
+> 覆盖 6 个"纯爬虫搞不定"的维度，要求 agent 做高强度跨域联想 + 多 agent 并行抓取。
+
+---
+
+## 0. 为什么需要这份文档
+
+UZI-Skill 的 22 个维度里，有 6 个维度**爬虫只能拿到原始片段，无法产出有洞察的结论**：
+
+| 维度 | 爬虫产出 | 缺失的关键判断 |
+|---|---|---|
+| 3 · 宏观环境 | 利率/汇率/地缘/大宗的**新闻片段** | 这些宏观变量**如何具体传导到这只股**？ |
+| 7 · 行业景气 | 行业 PE 中位数、默认 TAM | 赛道在生命周期哪个阶段？谁是 winner？ |
+| 8 · 原材料 | 近 12 月大宗价格曲线 | 涨价能否顺价？毛利率弹性多少？ |
+| 9 · 期货关联 | 关联品种近 60 日走势 | 套保敞口多少？contango 暗示什么库存策略？ |
+| 13 · 政策与监管 | 政策搜索片段 | 这条政策对公司**具体业务**的影响？受益者是龙头还是新玩家？ |
+| 15 · 事件驱动 | 近期公告列表 | 每条事件的**货币化影响**？子公司业务的独立价值？并购意图？ |
+
+**关键观察**：这些维度的真正价值在于**连接**——把孤立片段连成因果链。纯爬虫给不了因果。
+
+## 示例 · 三条孤立数据如何连成一个论点
+
+```
+事件驱动：子公司中标 20 亿基建工程      ← raw 片段
+政策与监管：地方财政预算下修 15%          ← raw 片段
+原材料：钢铁期货近月上涨 8%               ← raw 片段
+────────────────────────────────────────
+agent 的因果链（这才是"分析"）：
+  "20 亿中标 → 但甲方是地方财政吃紧的城投公司 → 应收账款账期拉长
+   + 原材料涨 8% 又压缩毛利 → 这单工程看起来是利好、实际是拿利润换周转"
+```
+
+**这种连接必须由 agent 完成，脚本做不到。**
+
+---
+
+## 1. 多 Agent 分工（强制 PARALLEL 执行）
+
+完成这 6 维必须 spawn **3 个并行 sub-agent**，每 agent 负责 2 个强关联维度。禁止用 1 个
+agent 串行覆盖 6 维（串行跑至少 3×更慢，且容易漏掉跨域思考）。
+
+### 分组标准 · 强关联维度配对
+
+| Sub-agent | 维度 | 核心主轴 | 关键联想 |
+|---|---|---|---|
+| **A · Macro-Policy** | 3_macro + 13_policy | 宏观政策耦合 | 美联储 → 汇率 → 出口业务<br/>国家战略 → 行业补贴 → 公司能拿几成<br/>反垄断/环保 → 子公司业务被卡 |
+| **B · Industry-Events** | 7_industry + 15_events | 行业结构 + 公司动态 | 行业集中度拐点 → 龙头份额<br/>子公司合同 → 营收增厚测算<br/>并购新闻 → 整合者 vs 被整合<br/>研发进展 → 3-5 年估值跳跃 |
+| **C · Cost-Transmission** | 8_materials + 9_futures | 成本传导链 | 上游原材料涨价 → 毛利率弹性<br/>国产替代 → 采购成本长期下行<br/>期货 contango/backward → 备货策略<br/>套保敞口 → 财报意外 |
+
+### Sub-agent 启动模板（直接复制，主 agent 在 stage1 之后用 Agent tool 启动）
+
+**Sub-agent A · Macro-Policy Prompt**:
+```
+你要扮演一位擅长宏观研究 + 政策分析的首席策略师，深度分析这只股票的
+宏观环境（dim 3）和政策与监管（dim 13）维度。
+
+公司：{name} ({ticker})
+行业：{industry}
+主营业务：{main_business}
+子公司/投资版图：{subsidiaries_from_10K}
+
+原始数据位置：
+  - .cache/{ticker}/raw_data.json · dimensions["3_macro"]
+  - .cache/{ticker}/raw_data.json · dimensions["13_policy"]
+
+你必须回答的问题清单见 task2.5 第 2 节 Dim 3 和 Dim 13 的小节。
+
+强制动作：
+1. 用 WebSearch 搜 "2026 {industry} 国家政策"、"2026 {industry} 监管变化"
+2. 用 Chrome/Playwright MCP 打开以下 URL 抓取最新政策原文：
+   - https://www.gov.cn/zhengce/   (国务院)
+   - http://www.csrc.gov.cn/csrc/c106187/common_list.shtml  (证监会)
+   - https://www.miit.gov.cn/   (工信部，制造业相关)
+3. 至少给出 2 条【宏观 ↔ 政策】交叉因果链（任选 task2.5 第 3 节的 6 条之一）
+4. 评估政策的受益者：是龙头（市场化分配）还是新玩家（补贴扶持）？本股处于什么位置？
+
+输出必须严格按照 task2.5 第 5 节 schema，写到 agent_analysis.json 的
+qualitative_deep_dive["3_macro"] 和 ["13_policy"] 字段。每条 finding 必须带 url 引用。
+```
+
+**Sub-agent B · Industry-Events Prompt**:
+```
+你要扮演一位资深行业研究员 + 公司事件追踪师，深度分析这只股票的
+行业景气（dim 7）和事件驱动（dim 15）维度。
+
+公司：{name} ({ticker})
+行业：{industry}
+市值：{market_cap}
+最近 60 天公告数：{len(recent_news)}
+
+原始数据位置：
+  - .cache/{ticker}/raw_data.json · dimensions["7_industry"]
+  - .cache/{ticker}/raw_data.json · dimensions["15_events"]
+
+你必须回答的问题清单见 task2.5 第 2 节 Dim 7 和 Dim 15 的小节。
+
+强制动作：
+1. WebSearch："{name} 子公司 业务"、"{name} 并购 2026"、"{industry} 市场份额排名"
+2. 用 Chrome/Playwright MCP 打开：
+   - http://www.cninfo.com.cn/new/disclosure/stock?stockCode={code_raw}  (巨潮公告原文)
+   - https://xueqiu.com/S/{code_raw}/announcements  (雪球公告)
+   - https://xueqiu.com/S/{code_raw}/F10/industry  (雪球行业信息)
+3. 列出过去 90 天内公司/子公司的**所有重要事件**并做货币化影响估算
+4. 至少验证 1 条【行业 ↔ 事件】因果链（例如：行业集中度上升 → 龙头并购 → 本股是
+   收购方还是被收购方？）
+5. 若有子公司独立业务 → 做一次分部估值（SOTP），告诉我子公司如果独立上市值多少
+
+输出写入 qualitative_deep_dive["7_industry"] 和 ["15_events"]。
+```
+
+**Sub-agent C · Cost-Transmission Prompt**:
+```
+你要扮演一位成本分析专家 + 期货分析师，深度分析这只股票的
+原材料（dim 8）和期货关联（dim 9）维度。
+
+公司：{name} ({ticker})
+行业：{industry}
+历史毛利率：{gross_margin_history}
+
+原始数据位置：
+  - .cache/{ticker}/raw_data.json · dimensions["8_materials"]
+  - .cache/{ticker}/raw_data.json · dimensions["9_futures"]
+
+你必须回答的问题清单见 task2.5 第 2 节 Dim 8 和 Dim 9 的小节。
+
+强制动作：
+1. WebSearch："{name} 原材料 成本占比"、"{name} 套期保值 年报"、"{name} 国产替代"
+2. 用 Chrome/Playwright MCP 打开：
+   - https://data.eastmoney.com/futures/index.html
+   - https://www.shfe.com.cn/data/dailydata/   (上期所)
+3. **必做**：毛利率敏感性分析 —
+   假设核心原材料价格 +10% / +20% / -10% / -20%，毛利率相应变动多少？
+4. 从公司年报披露的"金融衍生品"段落判断套保敞口（买入 vs 卖出，名义本金）
+5. 至少验证 1 条【大宗 ↔ 期货】因果链
+
+输出写入 qualitative_deep_dive["8_materials"] 和 ["9_futures"]。
+```
+
+---
+
+## 2. 每维度的必答问题清单
+
+agent **必须逐条回答** — 回答不能是"不清楚"或"待查"。若找不到数据：
+- 先走 browser MCP / WebSearch
+- 再不行 → 在 `qualitative_deep_dive[dim].evidence` 里标 `{"source": "unknown", "finding": "该字段无公开数据"}`
+- 绝不留空 / 不写废话（"值得关注" / "需要观察"）
+
+### Dim 3 · 宏观环境（5 问）
+1. **利率周期**：当前处于加息 / 降息 / 平台期？对公司资金成本和 DCF 估值的影响是正是负？量化：每 +25bp 影响几个点 ROE
+2. **汇率敞口**：公司出口占营收多少？进口原料占成本多少？当前人民币趋势的净影响？
+3. **地缘政策**：关税 / 制裁 / 出口管制是否命中公司产品？列出具体产品线和目的地国家
+4. **大宗商品**：把 dim 8（原材料）和 dim 9（期货）的数据**引用进来**，不要重复描述，直接说宏观因素对它们的传导
+5. **需求指标**：当前 M2/社融/PMI 读数暗示下游需求的扩张还是收缩？与公司所在行业的历史相关性？
+
+### Dim 7 · 行业景气（7 问）
+1. **生命周期**：导入期 / 成长期 / 成熟期 / 衰退期？依据（历史 CAGR、渗透率、替代率）
+2. **TAM & 增速**：3 年预测 TAM 是多少亿？信达 / 中金 / 券商研报的分歧区间？
+3. **集中度变化**：过去 3 年 CR4 / CR8 变化（龙头在收割 or 分散）
+4. **波特五力速评**：上下游议价 / 替代品 / 进入壁垒 / 行业内竞争 · 每个打 1-5 分并解释
+5. **替代品风险**：是否有颠覆性技术（如 AI vs 传统 SaaS、新能源 vs 燃油车）威胁赛道？
+6. **公司地位**：本股在行业里排第几？龙头 / 追赶者 / 尾部？市占率数字
+7. **M&A 活跃度**：行业近 6 个月有无重大并购？本公司是整合者还是被整合对象？
+
+### Dim 8 · 原材料（5 问）
+1. **成本构成**：核心原材料占营业成本多少比例？引用年报或券商"成本拆解"章节
+2. **价格走势**：引用 dim 8 的 `price_history_12m`，指出当前处于过去 3 年百分位几？
+3. **顺价能力**（最关键）：原料涨 10% → 毛利率变化多少？测算逻辑：
+   - 如果合同定价机制 = 成本加成 → 基本能顺价
+   - 如果合同 = 固定价 → 压毛利
+   - 提供 3 档情景（+10% / +20% / +30%）下的毛利率
+4. **替代 / 长协**：是否有国产替代方案进行中？是否签了长单锁定原料价？
+5. **向上游一体化**：子公司是否涉及原料端（如电池厂做锂矿）？长期成本优势
+
+### Dim 9 · 期货关联（4 问）
+1. **Lead-lag 关系**：关联期货与公司股价的时滞关系（通常期货领先 1-3 个月）
+2. **套保敞口**：公司年报"金融衍生品"章节披露的名义本金多少？多头 / 空头？
+3. **Contango vs Backwardation**：当前曲线形态暗示什么库存策略？
+4. **异常持仓**：关联品种近期持仓异常变化对公司经营的影响？
+
+### Dim 13 · 政策与监管（6 问）
+1. **国家战略对齐度**：十五五规划 / 制造强国 / 双碳 / 数字经济 / 专精特新 — 公司符合哪几条？
+2. **近 6 个月新政策**：针对公司行业的新政策（补贴 / 税收 / 环保 / 安全 / 反垄断 / 出口管制）— 列出每一条的**原文摘录**和发文机构
+3. **受益者判断**（关键）：这条政策受益者是行业龙头还是新进入者？公司处于什么位置？
+4. **地方财政**：特别是基建 / 城投 / 公用事业类——地方财政压力如何传导到本公司？
+5. **资质与税率**：是否在高新技术认证 / 专精特新 / "小巨人"名单？税率优惠？
+6. **海外监管**：FDA / SEC / 欧盟 / 美国商务部实体清单等对出海业务的影响？
+
+### Dim 15 · 事件驱动（6 问）
+1. **近 30 天公告分类**：按"合同中标 / 研发进展 / 股东变动 / 诉讼 / 并购 / 业绩预告 / 其他"归类，给每类做计数和总金额
+2. **每条事件的货币化**：合同金额占营收多少 %？研发费用占营收？诉讼涉及金额？
+3. **催化剂日历**（未来 60 天）：年报 / 季报 / 业绩说明会 / 股东大会 / 限售解禁日期
+4. **子公司独立价值**（SOTP）：核心子公司如果独立上市，按同行 PE / PS 估值几何？与当前市值的比较
+5. **并购影响**（如有）：被并购方 / 并购方？交易对价？EPS 增厚或摊薄的一阶估算
+6. **监管调查 / 诉讼**：金额量级 + 判决概率（引用相似案例）
+
+---
+
+## 3. 跨域因果链 · agent 至少验证 3 条
+
+这 6 条是 UZI-Skill 总结的"最有信息量"的因果链。agent 在这 6 条里**挑至少 3 条**进行验证，
+结果写入 `qualitative_deep_dive[dim].associations[]`。
+
+### 链 1 · 宏观 → 原材料 → 毛利率
+```
+利率下行 → 大宗回调 → 公司原料成本 ↓ → 毛利率 ↑
+(关键问题：这只股对原料的毛利弹性是多少？dim 8 的敏感性表告诉你)
+```
+
+### 链 2 · 政策 → 行业 → 份额重分配
+```
+新政策发布（补贴 / 许可证 / 准入门槛）→ 强化 TAM 或压制旧玩家 →
+行业集中度变化 → 本公司份额上升 or 下降？
+(关键问题：政策的受益者是龙头还是新玩家？)
+```
+
+### 链 3 · 事件 → 估值跳跃
+```
+子公司中标大合同 / 重大研发突破 / 并购新业务 → 营收或利润分部估值 ↑↑ →
+DCF 和 SOTP 分歧 → 买入机会或假突破？
+```
+
+### 链 4 · 期货 → 财报
+```
+公司套保敞口（多 or 空）× 期货价格波动 → 财务报表非经常性损益 →
+下个季度利润 beat / miss
+```
+
+### 链 5 · 宏观 → 地方 → 公司
+```
+顶层宏观压力（利率高 / 房地产压制）→ 地方财政紧 → 城投付款慢 →
+工程类公司应收账款飙升 → 现金流恶化
+(特别适合：基建 / 园林 / 市政 / 公用事业)
+```
+
+### 链 6 · 行业整合 → 公司定位
+```
+并购活跃期 → 小公司被收购 + 龙头份额上升 →
+本股是整合者（上车）还是下一个被整合（套利）？
+(关键问题：估值是否已 price in 并购预期？)
+```
+
+---
+
+## 4. Browser/MCP 抓取 URL 模板
+
+直接复制到 sub-agent prompt 里让它用 Chrome/Playwright MCP 打开。
+**注意**：`push2.eastmoney.com` 和 `82.push2.eastmoney.com` 2026 年经常被反爬，优先用下面
+列出的可用域。
+
+### Dim 3 · 宏观
+```
+https://data.eastmoney.com/hsgt/board.html         (北向/南向资金面板)
+https://data.eastmoney.com/hgt/zb.html             (汇率)
+https://data.eastmoney.com/cjsj/pmi.html           (PMI)
+https://data.eastmoney.com/cjsj/cpi.html           (CPI)
+https://www.chinamoney.com.cn/chinese/               (中债)
+```
+
+### Dim 7 · 行业
+```
+https://xueqiu.com/S/{code}/F10/industry           (雪球 F10 行业信息)
+https://data.eastmoney.com/bkzj/                    (板块资金)
+https://www.iresearch.com.cn/                       (艾瑞)
+```
+
+### Dim 8/9 · 大宗 & 期货
+```
+https://data.eastmoney.com/futures/index.html      (期货总览)
+https://www.shfe.com.cn/data/dailydata/            (上期所日报)
+https://www.dce.com.cn/                             (大商所)
+https://www.czce.com.cn/                            (郑商所)
+https://www.100ppi.com/                             (生意社 · 现货)
+```
+
+### Dim 13 · 政策
+```
+https://www.gov.cn/zhengce/                         (国务院政策)
+http://www.csrc.gov.cn/csrc/c106187/common_list.shtml  (证监会监管动态)
+https://www.miit.gov.cn/                            (工信部)
+https://www.ndrc.gov.cn/xxgk/jd/                    (发改委政策解读)
+https://www.samr.gov.cn/                            (市场监管总局 · 反垄断)
+```
+
+### Dim 15 · 事件
+```
+http://www.cninfo.com.cn/new/disclosure/stock?stockCode={code_raw}  (巨潮)
+https://xueqiu.com/S/{code_raw}/announcements       (雪球公告聚合)
+https://www.eastmoney.com/                          (东财首页搜索)
+http://vip.stock.finance.sina.com.cn/corp/go.php/vCB_AllBulletin/stockid/{code_raw}.phtml  (新浪)
+```
+
+---
+
+## 5. 输出 Schema · 写回 agent_analysis.json
+
+6 个定性维度的分析全部写入 `.cache/{ticker}/agent_analysis.json` 的
+`qualitative_deep_dive` 字段（v2.4 新增）。结构严格约束：
+
+```json
+{
+  "agent_reviewed": true,
+  "dim_commentary": { "3_macro": "...", ... },
+  "panel_insights": "...",
+  "qualitative_deep_dive": {
+    "3_macro": {
+      "evidence": [
+        {
+          "source": "国务院.gov.cn | cninfo | xueqiu | websearch | browser | mx_api | annual_report",
+          "url": "https://www.gov.cn/zhengce/xxx.html",
+          "finding": "人民币兑美元 2026-04 中间价较年初贬值 2.1%；公司出口占营收 45%",
+          "retrieved_at": "2026-04-17"
+        }
+      ],
+      "associations": [
+        {
+          "link_to": "8_materials",
+          "chain_id": "链 1",
+          "causal_chain": "美联储加息 → 人民币贬值 → 公司进口铜原料成本 +3% → 毛利率 -1.2pp",
+          "estimated_impact": "影响 EPS 约 -0.08元"
+        }
+      ],
+      "conclusion": "宏观中性偏利空，主要拖累来自进口成本上行和出口议价弱化"
+    },
+    "7_industry": { ... },
+    "8_materials": { ... },
+    "9_futures": { ... },
+    "13_policy": { ... },
+    "15_events": { ... }
+  },
+  "great_divide_override": { ... },
+  "narrative_override": { ... }
+}
+```
+
+### 字段约束
+
+| 字段 | 类型 | 约束 |
+|---|---|---|
+| `evidence[]` | list[obj] | 每维 ≥ 2 条，每条必有 `url`（允许 `"source": "unknown"` 但必须说明） |
+| `associations[]` | list[obj] | 6 维合计 ≥ 3 条（对应第 3 节 6 条链中至少 3 条） |
+| `conclusion` | string | 1-2 句，必须引用 evidence 和/或 associations，禁止空泛话术 |
+| `dim_commentary[key]` | string | 必须 cite `qualitative_deep_dive[key].evidence[*].url` 中至少一条 |
+
+### 质量红线（违反即视为未完成）
+- ❌ evidence 为空、或 url 全部空字符串
+- ❌ associations 全部是 "宏观影响公司" 这种无具体量化的泛泛而谈
+- ❌ conclusion 出现"值得关注 / 需要观察 / 基本面良好"三词之一
+- ❌ 6 维 dim_commentary 复制 raw_data 的原始片段
+
+---
+
+## 6. 与现有 HARD-GATE 的关系
+
+- **HARD-GATE-NAME**（v2.3）：名字解析失败 → 早退
+- **HARD-GATE-DATAGAPS**（v2.3）：数据字段缺失 → agent 用浏览器补齐
+- **HARD-GATE-QUALITATIVE**（v2.4，本文档）：定性维度空洞 → agent 深度分析
+
+三个 gate 顺序执行：名字必须先解析对、数据尽量补全、再做定性深度分析。
+`stage2()` 读到 `qualitative_deep_dive` 缺失会打印黄色警示（不 abort，遵循 v2.3 的
+"agent 接管"原则）。
+
+---
+
+## 7. Performance 注意
+
+- 3 个 sub-agent 并行，每个跑 5-10 分钟（含 WebSearch + browser 抓取）
+- 总耗时 ≈ max(A, B, C) ≈ 10 分钟（vs 串行 30 分钟）
+- 确保 sub-agent 使用 Agent tool `subagent_type=general-purpose` 真并行启动
+- 不要让 sub-agent 之间等待彼此结果 — 完全独立
+
+---
+
+## 8. 例子 · 完整一条 evidence + association 的样子
+
+以"宁德时代"为例：
+
+```json
+"qualitative_deep_dive": {
+  "13_policy": {
+    "evidence": [
+      {
+        "source": "工信部",
+        "url": "https://www.miit.gov.cn/xwdt/gxdt/sjdt/art/2026/art_xxx.html",
+        "finding": "《2026 新能源汽车推广方案》明确补贴向 300Wh/kg 以上电芯倾斜，公司 Kirin 4.0 已达标",
+        "retrieved_at": "2026-04-17"
+      }
+    ],
+    "associations": [
+      {
+        "link_to": "7_industry",
+        "chain_id": "链 2",
+        "causal_chain": "补贴门槛抬高至 300Wh/kg → 中小电池厂无法达标 → 行业集中度 CR4 从 73% → 82% → 公司份额结构性上升",
+        "estimated_impact": "2027 年市占率从 38% → 44%，对应额外 EPS +0.54 元"
+      }
+    ],
+    "conclusion": "政策明显利好本股。新补贴标准实质上是壁垒强化工具，公司高端技术储备(Kirin 4.0) 转化为市场份额增益"
+  }
+}
+```
+
+注意：
+- 每条 evidence 都有**具体 URL**
+- association 标明**挂钩到哪个其他维度**
+- conclusion 明确表态（利好 / 利空 / 中性），不和稀泥
+- 给出**可验证的量化估算**（市占率变动、EPS 影响）

--- a/skills/deep-analysis/scripts/assemble_report.py
+++ b/skills/deep-analysis/scripts/assemble_report.py
@@ -2255,6 +2255,63 @@ def _render_competitive_analysis(dim22: dict) -> str:
     '''
 
 
+def _render_data_gap_banner(data_gaps: dict | None) -> str:
+    """v2.3 · Render orange banner listing data gaps. Returns empty string if no gaps.
+
+    Reads synthesis.data_gaps which is populated in stage2() from _data_gaps.json
+    (produced by data_integrity.generate_recovery_tasks). The banner tells readers
+    upfront that the report has known holes — no silent fake numbers.
+    """
+    if not isinstance(data_gaps, dict) or not data_gaps.get("tasks"):
+        return ""
+
+    tasks = data_gaps["tasks"]
+    total = len(tasks)
+    unresolved = data_gaps.get("unresolved", total)
+    ack = total - unresolved
+    cov = data_gaps.get("coverage_pct", 0)
+
+    # Build chip list — critical first, then optional, then enrichment
+    order = {"critical": 0, "optional": 1, "enrichment": 2}
+    sorted_tasks = sorted(tasks, key=lambda t: (order.get(t.get("severity"), 9), t.get("dim", "")))
+    chips_html: list[str] = []
+    for t in sorted_tasks[:20]:
+        cls = "chip"
+        if t.get("status") == "acknowledged":
+            cls += " ack"
+        chips_html.append(f'<span class="{cls}">{t.get("label","?")} · {t.get("dim","?")}</span>')
+    chips_block = "\n      ".join(chips_html)
+    overflow = ""
+    if len(sorted_tasks) > 20:
+        overflow = f'<span class="chip">+{len(sorted_tasks) - 20} 更多</span>'
+
+    subtitle = (
+        f"数据覆盖率 <strong>{cov}%</strong> · "
+        f"共 <strong>{total}</strong> 个字段未从脚本采集到"
+    )
+    if ack:
+        subtitle += f"（其中 <strong>{ack}</strong> 已由 agent 确认"
+        subtitle += "真的拿不到）"
+
+    hint = (
+        "Agent 已尝试浏览器抓取 / MX API / WebSearch / 逻辑推导；"
+        "划线字段为已确认无法补齐，其余字段显示为 “—”。"
+    )
+
+    return f'''<div class="data-gap-banner" role="alert">
+  <div class="icon">⚠️</div>
+  <div class="body">
+    <div class="title">DATA QUALITY · 本报告存在已知数据缺口</div>
+    <div class="subtitle">{subtitle}</div>
+    <div class="list">
+      {chips_block}
+      {overflow}
+    </div>
+    <div class="hint">{hint}</div>
+  </div>
+</div>'''
+
+
 def _render_institutional_section(raw: dict) -> str:
     """Combined dim 20/21/22 renderer — returns the full institutional modeling block."""
     dims = raw.get("dimensions", {}) or {}
@@ -2430,6 +2487,12 @@ def assemble(ticker: str) -> Path:
     template = template.replace(
         "<!-- INJECT_INSTITUTIONAL_MODELING -->",
         _render_institutional_section(raw),
+    )
+
+    # v2.3 · Data quality banner (only renders when synthesis.data_gaps present)
+    template = template.replace(
+        "<!-- INJECT_DATA_GAP_BANNER -->",
+        _render_data_gap_banner(syn.get("data_gaps")),
     )
 
     date = datetime.now().strftime("%Y%m%d")

--- a/skills/deep-analysis/scripts/assemble_report.py
+++ b/skills/deep-analysis/scripts/assemble_report.py
@@ -1842,21 +1842,79 @@ def render_fund_managers(managers: list) -> str:
     if len(cards) <= INITIAL_SHOW:
         return header + f'<div class="fund-mgr-grid">{"".join(cards)}</div>'
 
-    # Show first 6, hide rest behind expand button
+    # v2.4 · Top 6 用完整卡片；第 7 位起切换到紧凑行（头像+名字+5Y 收益+同类排名）
+    # 理由：热门股有 100+ 基金持有，全用大卡会把报告撑爆
     visible = "".join(cards[:INITIAL_SHOW])
-    hidden = "".join(cards[INITIAL_SHOW:])
+    compact_rows = [
+        _render_fund_compact_row(m, rank=i + 1 + INITIAL_SHOW)
+        for i, m in enumerate(managers_sorted[INITIAL_SHOW:])
+    ]
     hidden_count = len(cards) - INITIAL_SHOW
     uid = f"fm_{abs(hash(str(len(cards))))}"
 
     return header + f'''
     <div class="fund-mgr-grid">{visible}</div>
-    <div id="{uid}" class="fund-mgr-grid" style="display:none">{hidden}</div>
+    <div id="{uid}" class="fund-compact-list" style="display:none">
+      <div class="fund-compact-head">
+        <span class="fc-h-rank">#</span>
+        <span class="fc-h-avatar"></span>
+        <span class="fc-h-name">基金经理 / 基金</span>
+        <span class="fc-h-metric">5Y 累计</span>
+        <span class="fc-h-metric">同类排名</span>
+        <span class="fc-h-link"></span>
+      </div>
+      {"".join(compact_rows)}
+    </div>
     <div style="text-align:center;margin:16px 0">
-      <button onclick="var el=document.getElementById('{uid}');var btn=this;if(el.style.display==='none'){{el.style.display='grid';btn.textContent='收起 ▲'}}else{{el.style.display='none';btn.textContent='展开剩余 {hidden_count} 位基金经理 ▼'}}"
+      <button onclick="var el=document.getElementById('{uid}');var btn=this;if(el.style.display==='none'){{el.style.display='block';btn.textContent='收起 ▲'}}else{{el.style.display='none';btn.textContent='展开剩余 {hidden_count} 位（按 5Y 收益排名）▼'}}"
         style="background:#f59e0b;color:#fff;border:none;padding:10px 28px;border-radius:8px;font-size:14px;font-weight:700;cursor:pointer;transition:all 0.2s">
-        展开剩余 {hidden_count} 位基金经理 ▼
+        展开剩余 {hidden_count} 位（按 5Y 收益排名）▼
       </button>
     </div>'''
+
+
+def _render_fund_compact_row(m: dict, rank: int) -> str:
+    """One-line strip for fund managers ranked 7+. Used in expanded compact list.
+
+    Reuses color/percentile logic from render_fund_managers so styling stays in sync.
+    """
+    name = m.get("name", "—")
+    fund_name = m.get("fund_name", "—")
+    fund_code = m.get("fund_code", "")
+    avatar = m.get("avatar", "")
+    ret_5y = m.get("return_5y", 0) or 0
+    peer_rank = m.get("peer_rank_pct", 50) or 50
+
+    ret_color = COLOR_BULL if ret_5y > 0 else COLOR_BEAR
+    rank_color = COLOR_BULL if peer_rank < 20 else COLOR_GOLD if peer_rank < 50 else COLOR_BEAR
+
+    # rank badge: top 3 gold, 4-10 silver, rest plain
+    if rank <= 3:
+        badge_style = "background:linear-gradient(135deg,#f59e0b,#d97706);color:#fff"
+    elif rank <= 10:
+        badge_style = "background:#e2e8f0;color:#475569"
+    else:
+        badge_style = "background:#f1f5f9;color:#64748b"
+
+    if avatar:
+        avatar_html = f'<img src="avatars/{avatar}.svg" class="fc-avatar" alt="">'
+    else:
+        avatar_html = f'<div class="fc-avatar fc-avatar-ph">{name[0] if name else "?"}</div>'
+
+    fund_url = m.get("fund_url", f"https://fund.eastmoney.com/{fund_code}.html")
+    sign = "+" if ret_5y > 0 else ""
+
+    return f'''<div class="fund-compact-row">
+  <span class="fc-rank" style="{badge_style}">{rank}</span>
+  {avatar_html}
+  <div class="fc-info">
+    <div class="fc-name">{name}</div>
+    <div class="fc-fund">{fund_name}</div>
+  </div>
+  <span class="fc-return" style="color:{ret_color}">{sign}{ret_5y:.1f}%</span>
+  <span class="fc-rank-pct" style="color:{rank_color}">前 {peer_rank}%</span>
+  <a href="{fund_url}" target="_blank" rel="noopener" class="fc-link" title="查看基金详情">→</a>
+</div>'''
 
 
 def render_debate_rounds(debate: dict) -> str:

--- a/skills/deep-analysis/scripts/fetch_basic.py
+++ b/skills/deep-analysis/scripts/fetch_basic.py
@@ -1,4 +1,14 @@
-"""Dimension 0 · 基础信息 (name, code, industry, price, mcap, PE, PB)."""
+"""Dimension 0 · 基础信息 (name, code, industry, price, mcap, PE, PB).
+
+Returns either:
+    - Success:       {"ticker", "market", "data", "source", "fallback": False}
+    - Name error:    {"ticker", "error": "name_not_resolved", "user_input",
+                     "suggestions": [...], "source": "name_resolver", "fallback": True}
+
+The second shape lets stage1() early-return and hand off to the agent / user
+for disambiguation, instead of silently running 22 fetchers with a garbage
+ticker and producing a half-empty report (see the 北部港湾 incident).
+"""
 import json
 import sys
 
@@ -8,9 +18,23 @@ from lib.market_router import is_chinese_name, parse_ticker
 
 def main(user_input: str) -> dict:
     if is_chinese_name(user_input):
-        ti = ds.resolve_chinese_name(user_input) or parse_ticker(user_input)
+        r = ds.resolve_chinese_name_rich(user_input)
+        if r["resolved"] is None:
+            # Ambiguous or unresolvable — surface candidates for UI confirmation.
+            return {
+                "ticker": user_input,
+                "market": None,
+                "data": {},
+                "error": "name_not_resolved",
+                "user_input": user_input,
+                "suggestions": r["candidates"][:5],
+                "source": f"name_resolver:{r['source']}",
+                "fallback": True,
+            }
+        ti = r["resolved"]
     else:
         ti = parse_ticker(user_input)
+
     data = ds.fetch_basic(ti)
     return {
         "ticker": ti.full,

--- a/skills/deep-analysis/scripts/fetch_fund_holders.py
+++ b/skills/deep-analysis/scripts/fetch_fund_holders.py
@@ -223,7 +223,14 @@ def _holding_quarters(ticker_code: str, fund_code: str, max_lookback: int = 8) -
     return count, trend
 
 
-def main(ticker: str, limit: int = 50) -> dict:
+def main(ticker: str, limit: int | None = None) -> dict:
+    """Fetch ALL active-equity funds holding this stock.
+
+    v2.4: `limit` default changed from 50 → None (no cap). Hot stocks like 贵州茅台
+    routinely have 100+ active funds holding them; the old hard-cap silently
+    dropped bottom holders, making "抄作业" incomplete. Pass `limit=N` only
+    for quick debugging.
+    """
     ti = parse_ticker(ticker)
     if ti.market != "A":
         return {
@@ -244,25 +251,23 @@ def main(ticker: str, limit: int = 50) -> dict:
 
     active_holders = [h for h in holders if "error" not in h and _is_active_fund(h.get("基金名称", ""))]
     total_funds = len([h for h in holders if "error" not in h])
-    managers: list[dict] = []
+    iter_holders = active_holders if limit is None else active_holders[:limit]
 
-    for row in active_holders[:limit]:
+    # v2.4 · 并行计算每个基金的 5Y 统计（以前 100+ 基金串行跑约 30s）
+    def _build_row(row: dict) -> dict | None:
         fund_code = str(row.get("基金代码", ""))
         fund_name = str(row.get("基金名称", ""))
         if not fund_code:
-            continue
-
+            return None
         stats = cached(fund_code, f"fund_stats_{fund_code}", lambda: compute_fund_stats(fund_code), ttl=TTL_QUARTERLY)
         if not stats or "error" in stats:
             stats = {}
-
         manager_name = fetch_fund_manager_name(fund_code) or "—"
         try:
             position_pct = float(row.get("占市值比例", 0) or row.get("占流通股比例", 0))
         except (ValueError, TypeError):
             position_pct = 0.0
-
-        managers.append({
+        return {
             "name": manager_name,
             "fund_name": fund_name,
             "fund_code": fund_code,
@@ -278,17 +283,49 @@ def main(ticker: str, limit: int = 50) -> dict:
             "peer_rank_pct": 50,
             "nav_history": stats.get("nav_history", []),
             "fund_url": f"https://fund.eastmoney.com/{fund_code}.html",
-        })
+        }
+
+    # 并行度默认 3（低于 akshare 在 Py3.13 下 libffi 并发的不稳定阈值）；
+    # 设置 UZI_FUND_WORKERS=1 可切换为纯串行。
+    import os as _os
+    _workers = int(_os.environ.get("UZI_FUND_WORKERS", "3"))
+    managers: list[dict] = []
+    if _workers <= 1:
+        for row in iter_holders:
+            try:
+                r = _build_row(row)
+                if r is not None:
+                    managers.append(r)
+            except Exception:
+                continue
+    else:
+        from concurrent.futures import ThreadPoolExecutor, as_completed
+        with ThreadPoolExecutor(max_workers=_workers) as pool:
+            futures = [pool.submit(_build_row, row) for row in iter_holders]
+            for fut in as_completed(futures):
+                try:
+                    r = fut.result()
+                    if r is not None:
+                        managers.append(r)
+                except Exception:
+                    continue
 
     # Sort by 5Y return
     managers.sort(key=lambda m: m.get("return_5y", 0), reverse=True)
 
+    passive_count = max(0, total_funds - len(active_holders))
     return {
         "ticker": ti.full,
         "data": {
             "fund_managers": managers,
             "total_funds_holding": total_funds,
-            "_note": f"共 {total_funds} 家基金持有本股（含 ETF/指数），显示 top {len(managers)} 位主动权益基金经理",
+            "active_funds_count": len(managers),
+            "passive_funds_filtered": passive_count,
+            "_note": (
+                f"共 {total_funds} 家基金持有本股 · "
+                f"收录 {len(managers)} 家主动权益基金（已按 5Y 累计收益排序）· "
+                f"过滤 {passive_count} 家 ETF/指数基金"
+            ),
         },
         "source": "akshare:stock_fund_stock_holder + fund_open_fund_info_em",
         "fallback": False,

--- a/skills/deep-analysis/scripts/lib/data_integrity.py
+++ b/skills/deep-analysis/scripts/lib/data_integrity.py
@@ -157,6 +157,119 @@ def validate(raw: dict) -> dict:
     }
 
 
+# ═══════════════════════════════════════════════════════════════
+# Recovery task generation
+# ═══════════════════════════════════════════════════════════════
+
+# Per-field recovery hints · used by agents to prioritize retry strategy.
+# Order matters — browser > MX > WebSearch > inference.
+_RECOVERY_HINTS: dict[tuple[str, str], list[str]] = {
+    ("0_basic", "name"):         ["mx: '{code} 公司简称'", "browser: https://xueqiu.com/S/{code_raw}", "ws: '{code} 公司简介'"],
+    ("0_basic", "price"):        ["mx: '{code} 最新价'", "browser: https://xueqiu.com/S/{code_raw}", "ws: '{code} 股价 2026'"],
+    ("0_basic", "industry"):     ["mx: '{code} 所属申万行业'", "browser: https://xueqiu.com/S/{code_raw}/F10", "ws: '{code} 所属行业'"],
+    ("0_basic", "market_cap"):   ["mx: '{code} 总市值'", "browser: https://quote.eastmoney.com/{eastmoney_code}.html", "ws: '{code} 市值'"],
+    ("0_basic", "pe_ttm"):       ["mx: '{code} 市盈率TTM'", "browser: https://xueqiu.com/S/{code_raw}", "infer: 市值 / 归母净利润"],
+    ("0_basic", "pb"):           ["mx: '{code} 市净率'", "browser: https://xueqiu.com/S/{code_raw}"],
+    ("1_financials", "roe_history"):        ["mx: '{code} 最近5年ROE'", "browser: https://xueqiu.com/S/{code_raw}/F10/main"],
+    ("1_financials", "revenue_history"):    ["mx: '{code} 最近5年营业收入'", "browser: https://xueqiu.com/S/{code_raw}/F10/main"],
+    ("1_financials", "net_profit_history"): ["mx: '{code} 最近5年净利润'", "browser: https://xueqiu.com/S/{code_raw}/F10/main"],
+    ("1_financials", "financial_health"):   ["infer: 从 ROE/debt_ratio/fcf 综合判断", "mx: '{code} 财务健康度'"],
+    ("2_kline", "stage"):        ["infer: 从 ma20/ma60 多空排列推断 Wyckoff stage", "browser: https://xueqiu.com/S/{code_raw}"],
+    ("10_valuation", "pe"):            ["mx: '{code} 市盈率'", "browser: https://xueqiu.com/S/{code_raw}"],
+    ("10_valuation", "pe_quantile"):   ["mx: '{code} PE 5年分位数'", "ws: '{code} PE历史分位'"],
+    ("10_valuation", "pb_quantile"):   ["mx: '{code} PB 5年分位数'", "ws: '{code} PB历史分位'"],
+    ("7_industry", "growth"):    ["mx: '{industry} 行业增速 2026'", "ws: '{industry} 行业规模 增速 2026'"],
+    ("14_moat", "scores"):       ["agent: Porter 5 Forces + web search 护城河评分"],
+}
+
+# Enrichment dim recovery hints (when a whole dim is empty).
+_ENRICHMENT_HINTS: dict[str, list[str]] = {
+    "3_macro":        ["ws: '中国 {industry} 宏观环境 利率 2026'"],
+    "4_peers":        ["mx: '{industry} 同行业公司 市值排名'", "ws: '{name} 同行业竞争者 对比'"],
+    "5_chain":        ["browser: https://xueqiu.com/S/{code_raw}/F10", "ws: '{name} 上下游产业链'"],
+    "6_research":     ["mx: '{code} 券商研报 目标价'", "ws: '{name} 最新研报 2026'"],
+    "7_industry":     ["mx: '{industry} 行业规模 TAM'", "ws: '{industry} 行业景气 2026'"],
+    "8_materials":    ["ws: '{name} 原材料 成本构成'"],
+    "9_futures":      ["ws: '{industry} 期货 相关品种'"],
+    "11_governance":  ["mx: '{code} 股东结构 高管减持'", "browser: https://quote.eastmoney.com/{eastmoney_code}.html"],
+    "12_capital_flow":["mx: '{code} 北向持仓 融资融券'", "browser: https://data.eastmoney.com/zlsj/{code_raw}.html"],
+    "13_policy":      ["ws: '{industry} 最新政策 2026'"],
+    "14_moat":        ["ws: '{name} 核心竞争力 技术壁垒 市场份额'"],
+    "15_events":      ["mx: '{code} 最新公告'", "ws: '{name} {code} 最新公告 中标 研发 2026'"],
+    "16_lhb":         ["mx: '{code} 龙虎榜'", "browser: https://data.eastmoney.com/stock/lhb/{code_raw}.html"],
+    "17_sentiment":   ["browser: https://xueqiu.com/S/{code_raw}", "ws: 'site:xueqiu.com {code}'"],
+    "18_trap":        ["infer: 从龙虎榜+换手率+涨跌幅综合判断"],
+    "19_contests":    ["ws: '{code} 实盘比赛 持仓'"],
+}
+
+
+def generate_recovery_tasks(raw: dict, integrity: dict) -> list[dict]:
+    """Turn an integrity report into agent-actionable recovery tasks.
+
+    Each task is self-contained with context (code, industry, name) baked in,
+    so an agent can execute it without re-reading raw_data. Severity ordering
+    lets the agent focus on critical gaps first.
+
+    Returns:
+        list[{"dim", "field", "label", "severity", "suggested_actions", "status"}]
+    """
+    dims = raw.get("dimensions", {}) or {}
+    basic = (dims.get("0_basic") or {}).get("data") or {}
+    code = basic.get("code") or raw.get("ticker") or ""
+    industry = (dims.get("7_industry") or {}).get("data", {}).get("industry") or basic.get("industry") or "综合"
+    name = basic.get("name") or raw.get("ticker") or code
+    code_raw = code.split(".")[0] if "." in code else code
+    # EastMoney uses 0/1 prefix for SZ/SH
+    eastmoney_code = (("1." if code.endswith(".SH") else "0.") + code_raw) if code_raw else ""
+
+    ctx = {
+        "code": code,
+        "code_raw": code_raw,
+        "eastmoney_code": eastmoney_code,
+        "name": name,
+        "industry": industry,
+    }
+
+    def _render(actions: list[str]) -> list[str]:
+        rendered = []
+        for a in actions:
+            try:
+                rendered.append(a.format(**ctx))
+            except (KeyError, IndexError):
+                rendered.append(a)
+        return rendered
+
+    tasks: list[dict] = []
+
+    # Critical + optional missing fields
+    for entry in integrity.get("missing_critical", []) + integrity.get("missing_optional", []):
+        key = (entry["dim"], entry["path"])
+        hints = _RECOVERY_HINTS.get(key, ["ws: '{name} {label}'".format(name=name, label=entry["label"])])
+        severity = "critical" if entry in integrity.get("missing_critical", []) else "optional"
+        tasks.append({
+            "dim": entry["dim"],
+            "field": entry["path"],
+            "label": entry["label"],
+            "severity": severity,
+            "suggested_actions": _render(hints),
+            "status": "pending",
+        })
+
+    # Whole-dim enrichment gaps
+    for entry in integrity.get("missing_enrichment", []):
+        hints = _ENRICHMENT_HINTS.get(entry["dim"], ["ws: '{name} {label}'".format(name=name, label=entry["label"])])
+        tasks.append({
+            "dim": entry["dim"],
+            "field": "_entire_dim",
+            "label": entry["label"],
+            "severity": "enrichment",
+            "suggested_actions": _render(hints),
+            "status": "pending",
+        })
+
+    return tasks
+
+
 def format_report(report: dict) -> str:
     """Human-readable integrity report for console output."""
     lines: list[str] = []

--- a/skills/deep-analysis/scripts/lib/data_sources.py
+++ b/skills/deep-analysis/scripts/lib/data_sources.py
@@ -7,6 +7,7 @@ Install: pip install akshare yfinance pandas requests
 """
 from __future__ import annotations
 
+import os
 import time
 from typing import Any
 
@@ -75,6 +76,44 @@ def _fetch_basic_a(ti: TickerInfo) -> dict:
         raise RuntimeError("akshare not installed")
     out = {"code": ti.full}
     xq_symbol = ("SH" if ti.full.endswith("SH") else "SZ") + ti.code
+
+    # TIER 0 (optional): MX 妙想 Skills Hub — official NLP API. Used when MX_APIKEY is set.
+    # Much more stable than scraping push2.eastmoney.com in Mainland networks.
+    if _mx_available():
+        try:
+            from .mx_api import MXClient
+            client = MXClient()
+            snap = client.fetch_snapshot(ti.code)
+            if snap:
+                # MX returns human-readable keys like "最新价", "总市值", "PE(TTM)"
+                # Normalize into our schema where possible; ignore what we can't map.
+                def _mx_num(*labels):
+                    for lb in labels:
+                        v = snap.get(lb)
+                        if v is None or v == "" or v == "-":
+                            continue
+                        try:
+                            return float(v)
+                        except (ValueError, TypeError):
+                            continue
+                    return None
+
+                price = _mx_num("最新价", "收盘价", "当前价")
+                if price:
+                    out.update({
+                        "name": out.get("name") or (snap.get("_mx_entity") or "").split("(")[0].strip() or None,
+                        "price": price,
+                        "pe_ttm": _mx_num("市盈率(TTM)", "PE(TTM)", "PE"),
+                        "pb": _mx_num("市净率", "PB"),
+                        "market_cap_raw": _mx_num("总市值", "市值"),
+                        "industry": out.get("industry") or snap.get("所属行业") or snap.get("申万行业") or None,
+                    })
+                    mcap_raw = out.get("market_cap_raw")
+                    if mcap_raw:
+                        out["market_cap"] = f"{round(mcap_raw / 1e8, 1)}亿"
+                    out["_fallback_snap"] = "mx-snapshot"
+        except Exception as e:
+            out["_mx_err"] = f"{type(e).__name__}: {str(e)[:120]}"
 
     # PRIMARY: stock_individual_basic_info_xq (XueQiu backend, bypasses eastmoney push2)
     # Aggressive retry: 4 attempts with 2s base delay because XueQiu SSL sometimes flakes
@@ -769,53 +808,111 @@ def _fetch_research_impl(ti: TickerInfo) -> list[dict]:
 
 
 # ─────────────────────────────────────────────────────────────
-# Top-level: resolve Chinese name → ticker (uses akshare a-share spot table)
+# Top-level: resolve Chinese name → ticker
 # ─────────────────────────────────────────────────────────────
-def resolve_chinese_name(name: str) -> TickerInfo | None:
-    """Resolve Chinese stock name to TickerInfo. Multi-fallback:
-    1. akshare A-share spot table (fast but often blocked)
-    2. akshare stock_info_a_code_name (lighter weight)
-    3. DuckDuckGo search as last resort
+# Is MX (东方财富妙想) API available? Checked at import time for quick gating.
+def _mx_available() -> bool:
+    """Checked at call-time so callers can set MX_APIKEY after import (e.g. from .env)."""
+    return bool(os.environ.get("MX_APIKEY"))
+
+
+# Back-compat constant (some callers may reference it).
+MX_AVAILABLE = _mx_available()
+
+
+def resolve_chinese_name_rich(name: str) -> dict:
+    """Resolve a Chinese stock name with full candidate info for user-facing suggestions.
+
+    Returns:
+        {"resolved":    TickerInfo | None,   # set only on confident match
+         "candidates":  list[dict],           # up to 5 candidates for UI disambiguation
+         "source":      "mx"|"exact"|"fuzzy"|"none",
+         "user_input":  name}
+
+    Match order (most accurate first):
+        1. MX 妙想 API — official NLP, handles character-order typos ("北部港湾"→"北部湾港")
+        2. akshare exact substring (preserves legacy behaviour for valid names)
+        3. local Levenshtein fuzzy match against the full A-share name index
+
+    Callers that need the legacy `TickerInfo | None` signature should use
+    `resolve_chinese_name()` (thin wrapper).
     """
-    # Fallback 1: akshare spot table
-    if ak is not None:
+    user_input = name
+
+    # Tier 1: MX API
+    if _mx_available():
         try:
-            df = ak.stock_zh_a_spot_em()
-            row = df[df["名称"].str.contains(name, na=False)]
-            if not row.empty:
-                code = str(row.iloc[0]["代码"])
-                return parse_ticker(code)
+            from .mx_api import MXClient
+            client = MXClient()
+            hits = client.resolve_entity(name)
+            if hits:
+                h = hits[0]
+                ti = parse_ticker(h["secuCode"])
+                cands = [
+                    {"code": x["secuCode"], "name": x["fullName"],
+                     "distance": 0, "source": "mx"}
+                    for x in hits[:5]
+                ]
+                return {"resolved": ti, "candidates": cands,
+                        "source": "mx", "user_input": user_input}
         except Exception:
             pass
 
-    # Fallback 2: akshare code-name mapping (smaller, less likely to be blocked)
+    # Tier 2: akshare exact substring (legacy)
     if ak is not None:
-        try:
-            df = ak.stock_info_a_code_name()
-            row = df[df["name"].str.contains(name, na=False)] if "name" in df.columns else df[df.iloc[:, 1].str.contains(name, na=False)]
-            if not row.empty:
-                code = str(row.iloc[0].iloc[0])  # first column = code
-                return parse_ticker(code)
-        except Exception:
-            pass
+        for fetch in (
+            lambda: ak.stock_zh_a_spot_em(),
+            lambda: ak.stock_info_a_code_name(),
+        ):
+            try:
+                df = fetch()
+                if df is None or df.empty:
+                    continue
+                name_col = "名称" if "名称" in df.columns else ("name" if "name" in df.columns else df.columns[1])
+                code_col = "代码" if "代码" in df.columns else ("code" if "code" in df.columns else df.columns[0])
+                row = df[df[name_col].astype(str).str.contains(name, na=False)]
+                if not row.empty:
+                    code = str(row.iloc[0][code_col])
+                    matched_name = str(row.iloc[0][name_col])
+                    ti = parse_ticker(code)
+                    return {"resolved": ti,
+                            "candidates": [{"code": ti.full, "name": matched_name,
+                                            "distance": 0, "source": "exact"}],
+                            "source": "exact", "user_input": user_input}
+            except Exception:
+                continue
 
-    # Fallback 3: DuckDuckGo search
+    # Tier 3: local fuzzy match
     try:
-        from duckduckgo_search import DDGS
-        with DDGS() as ddgs:
-            query = f"{name} A股 股票代码"
-            results = list(ddgs.text(query, max_results=3))
-            import re
-            for r in results:
-                text = f"{r.get('title', '')} {r.get('body', '')}"
-                # Match 6-digit stock codes
-                codes = re.findall(r'\b([036]\d{5})\b', text)
-                if codes:
-                    return parse_ticker(codes[0])
+        from .name_matcher import fuzzy_match
+        hits = fuzzy_match(name, top_k=5, max_distance=2)
     except Exception:
-        pass
+        hits = []
+    if hits:
+        cands = [
+            {"code": parse_ticker(h["code"]).full, "name": h["name"],
+             "distance": h["distance"], "source": "fuzzy"}
+            for h in hits
+        ]
+        # Only auto-resolve if a single dominant candidate (distance 0, or uniquely closer)
+        auto = None
+        if hits[0]["distance"] == 0:
+            auto = parse_ticker(hits[0]["code"])
+        return {"resolved": auto, "candidates": cands,
+                "source": "fuzzy", "user_input": user_input}
 
-    return None
+    return {"resolved": None, "candidates": [],
+            "source": "none", "user_input": user_input}
+
+
+def resolve_chinese_name(name: str) -> TickerInfo | None:
+    """Legacy shim. Returns TickerInfo only when we are confident (MX/exact/fuzzy-d=0).
+
+    For ambiguous matches, callers should use `resolve_chinese_name_rich()` to
+    see the candidate list and ask the user.
+    """
+    r = resolve_chinese_name_rich(name)
+    return r["resolved"]
 
 
 if __name__ == "__main__":

--- a/skills/deep-analysis/scripts/lib/mx_api.py
+++ b/skills/deep-analysis/scripts/lib/mx_api.py
@@ -1,0 +1,218 @@
+"""Thin client for 东方财富妙想 Skills Hub API (`mkapi2.dfcfs.com/finskillshub`).
+
+This is an OFFICIAL, authenticated data source with far better stability than
+scraping `push2.eastmoney.com` (which is commonly blocked in 2026 Mainland
+networks). Requires a free API key from https://dl.dfcfs.com/m/itc4 exposed as
+the env var `MX_APIKEY`.
+
+Usage:
+    from lib.mx_api import MXClient
+    client = MXClient()                              # reads MX_APIKEY from env
+    if client.available:
+        hits = client.resolve_entity("北部湾港")
+        snap = client.fetch_snapshot("000582")
+    else:
+        # fall back to xueqiu / akshare chain
+
+Endpoints (header must carry `apikey: <MX_APIKEY>`):
+    POST /finskillshub/api/claw/query        — natural-language financial data
+    POST /finskillshub/api/claw/news-search  — news / announcements
+
+All requests go through `lib.cache.cached` with a 30-minute TTL to cap spend.
+"""
+from __future__ import annotations
+
+import os
+import time
+from typing import Any, Optional
+
+from .cache import cached
+
+try:
+    import requests
+except ImportError:
+    requests = None
+
+
+BASE = "https://mkapi2.dfcfs.com/finskillshub/api/claw"
+QUERY_URL = f"{BASE}/query"
+NEWS_URL = f"{BASE}/news-search"
+
+_MX_TTL = 30 * 60  # 30 min — MX responses are semi-fresh, cache to cap quota
+
+
+def _post(url: str, body: dict, api_key: str, timeout: int = 30, attempts: int = 2) -> dict:
+    """POST with small retry. Returns parsed JSON or {'error': ...}."""
+    if requests is None:
+        return {"error": "requests library missing"}
+    headers = {"Content-Type": "application/json", "apikey": api_key}
+    last_err = None
+    for i in range(attempts):
+        try:
+            r = requests.post(url, headers=headers, json=body, timeout=timeout)
+            if r.status_code != 200:
+                last_err = f"HTTP {r.status_code}: {r.text[:200]}"
+                # 401/403: don't retry, key issue
+                if r.status_code in (401, 403):
+                    break
+                time.sleep(1.0 * (i + 1))
+                continue
+            return r.json()
+        except Exception as e:
+            last_err = f"{type(e).__name__}: {str(e)[:200]}"
+            time.sleep(1.0 * (i + 1))
+    return {"error": last_err or "unknown"}
+
+
+class MXClient:
+    """Client for 妙想 Skills Hub. Safe to instantiate without a key — check `.available`."""
+
+    def __init__(self, api_key: Optional[str] = None):
+        self.api_key = api_key or os.getenv("MX_APIKEY") or ""
+        self.available = bool(self.api_key)
+
+    # ── Raw endpoints ─────────────────────────────────────────
+
+    def query(self, tool_query: str) -> dict:
+        """Natural-language query. Cached 30 min."""
+        if not self.available:
+            return {"error": "MX_APIKEY not set"}
+
+        def _fetch():
+            return _post(QUERY_URL, {"toolQuery": tool_query}, self.api_key)
+
+        return cached("_global", f"mx_query__{tool_query[:80]}", _fetch, ttl=_MX_TTL)
+
+    def news_search(self, query: str) -> dict:
+        """News / announcement search. Cached 30 min."""
+        if not self.available:
+            return {"error": "MX_APIKEY not set"}
+
+        def _fetch():
+            return _post(NEWS_URL, {"query": query}, self.api_key)
+
+        return cached("_global", f"mx_news__{query[:80]}", _fetch, ttl=_MX_TTL)
+
+    # ── High-level helpers ────────────────────────────────────
+
+    def resolve_entity(self, name: str) -> list[dict]:
+        """Map a Chinese stock name (possibly with typo) to code candidates.
+
+        Returns list of {"fullName", "secuCode", "entityType"}. Empty on failure.
+        The MX NLP layer handles character-order typos gracefully.
+        """
+        if not self.available:
+            return []
+        result = self.query(f"{name} 股票代码 所属行业")
+        return _extract_entity_tags(result)
+
+    def fetch_snapshot(self, code_or_name: str) -> dict:
+        """Best-effort snapshot (price / mcap / PE / PB / industry).
+
+        Returns flat dict with whatever fields could be extracted; empty dict on failure.
+        """
+        if not self.available:
+            return {}
+        result = self.query(f"{code_or_name} 最新价 总市值 PE PB 所属行业 主营业务")
+        return _extract_first_table_row(result)
+
+
+# ═══════════════════════════════════════════════════════════════
+# Response parsers
+# ═══════════════════════════════════════════════════════════════
+
+def _extract_entity_tags(result: dict) -> list[dict]:
+    """Extract entity info from MX query response. Multi-source parse because
+    the top-level `entityTagDTOList` is often empty for NLP-resolved queries —
+    the actual code lives inside each `dataTableDTO.code` / `.entityName`.
+    """
+    import re
+
+    if not isinstance(result, dict) or result.get("error"):
+        return []
+    if result.get("status") not in (0, None):
+        return []
+    data = result.get("data") or {}
+    inner = data.get("data") or {}
+    sr = inner.get("searchDataResultDTO") or {}
+
+    out: list[dict] = []
+    seen: set[str] = set()
+
+    # Source 1: top-level entityTagDTOList (rare but authoritative when present)
+    for t in sr.get("entityTagDTOList") or []:
+        if not isinstance(t, dict):
+            continue
+        full_name = t.get("fullName") or t.get("shortName") or ""
+        code = t.get("secuCode") or t.get("code") or ""
+        etype = t.get("entityTypeName") or t.get("entityType") or ""
+        if full_name and code and code not in seen:
+            seen.add(code)
+            out.append({"fullName": full_name, "secuCode": code, "entityType": etype})
+
+    # Source 2: dataTableDTOList[].code / .entityName (MX NLP-resolved typical path)
+    for dto in sr.get("dataTableDTOList") or []:
+        if not isinstance(dto, dict):
+            continue
+        code = (dto.get("code") or "").strip()
+        entity_name = (dto.get("entityName") or "").strip()
+        if not code or code in seen:
+            continue
+        # entityName is "北部湾港(000582.SZ)" — strip parenthetical code to get clean name
+        m = re.match(r"^(.+?)\s*[（(][^)）]+[)）]\s*$", entity_name)
+        clean_name = m.group(1).strip() if m else entity_name
+        seen.add(code)
+        out.append({
+            "fullName": clean_name,
+            "secuCode": code,
+            "entityType": dto.get("dataType", "") or "股票",
+        })
+
+    return out
+
+
+def _extract_first_table_row(result: dict) -> dict:
+    """Extract indicator→value map from the first dataTableDTO. Best-effort."""
+    if not isinstance(result, dict) or result.get("error"):
+        return {}
+    data = result.get("data") or {}
+    inner = data.get("data") or {}
+    sr = inner.get("searchDataResultDTO") or {}
+    dto_list = sr.get("dataTableDTOList") or []
+    if not dto_list or not isinstance(dto_list[0], dict):
+        return {}
+    dto = dto_list[0]
+    table = dto.get("table") or {}
+    if not isinstance(table, dict):
+        return {}
+    name_map = dto.get("nameMap") or {}
+    if isinstance(name_map, list):
+        name_map = {str(i): v for i, v in enumerate(name_map)}
+    headers = table.get("headName") or []
+
+    out: dict[str, Any] = {"_mx_entity": (dto.get("entityName") or "")}
+    for key, values in table.items():
+        if key == "headName":
+            continue
+        label = name_map.get(key) or name_map.get(str(key)) or str(key)
+        if isinstance(values, list) and values:
+            # Take the most recent (last) value for snapshots; headName is date column.
+            out[str(label)] = values[-1]
+        else:
+            out[str(label)] = values
+    return out
+
+
+if __name__ == "__main__":
+    import json
+    import sys
+    q = sys.argv[1] if len(sys.argv) > 1 else "北部湾港"
+    c = MXClient()
+    print(f"available: {c.available}")
+    if not c.available:
+        print("Set MX_APIKEY to test. See .env.example.")
+        sys.exit(0)
+    print(f"\n── resolve_entity('{q}') ──")
+    print(json.dumps(c.resolve_entity(q), ensure_ascii=False, indent=2))
+    print(f"\n── fetch_snapshot('{q}') ──")
+    print(json.dumps(c.fetch_snapshot(q), ensure_ascii=False, indent=2))

--- a/skills/deep-analysis/scripts/lib/name_matcher.py
+++ b/skills/deep-analysis/scripts/lib/name_matcher.py
@@ -1,0 +1,158 @@
+"""Fuzzy matching for Chinese stock names · zero-dependency.
+
+Handles typo/character-order mistakes like "北部港湾" → "北部湾港" (000582.SZ).
+
+Two-stage pipeline:
+    1. Character-set Jaccard filter (fast; rules out >99% of the 5000-stock A-share universe)
+    2. Levenshtein distance ranking on survivors (accurate; picks the right reorder)
+
+A-share (code, name) index is loaded from akshare.stock_info_a_code_name() and cached
+for 7 days (names rarely change). Caller passes a plain Chinese string; we return a list
+of scored candidates.
+
+Usage:
+    from lib.name_matcher import fuzzy_match
+    hits = fuzzy_match("北部港湾", top_k=5)
+    # → [{"code": "000582", "name": "北部湾港", "distance": 1, "jaccard": 1.0}, ...]
+"""
+from __future__ import annotations
+
+from typing import Any
+
+from .cache import cached, TTL_STATIC
+
+try:
+    import akshare as ak
+except ImportError:
+    ak = None
+
+
+# ═══════════════════════════════════════════════════════════════
+# Primitive similarity metrics (pure stdlib)
+# ═══════════════════════════════════════════════════════════════
+
+def levenshtein(a: str, b: str) -> int:
+    """Edit distance · classic two-row DP. O(len(a) * len(b)) time, O(len(b)) space."""
+    if a == b:
+        return 0
+    if not a:
+        return len(b)
+    if not b:
+        return len(a)
+    prev = list(range(len(b) + 1))
+    for i, ca in enumerate(a, start=1):
+        curr = [i] + [0] * len(b)
+        for j, cb in enumerate(b, start=1):
+            cost = 0 if ca == cb else 1
+            curr[j] = min(
+                curr[j - 1] + 1,       # insert
+                prev[j] + 1,           # delete
+                prev[j - 1] + cost,    # substitute
+            )
+        prev = curr
+    return prev[-1]
+
+
+def char_set_jaccard(a: str, b: str) -> float:
+    """Character-set Jaccard similarity (ignores ordering). 1.0 means same character multiset."""
+    sa, sb = set(a), set(b)
+    if not sa and not sb:
+        return 1.0
+    union = sa | sb
+    if not union:
+        return 0.0
+    return len(sa & sb) / len(union)
+
+
+# ═══════════════════════════════════════════════════════════════
+# A-share name index
+# ═══════════════════════════════════════════════════════════════
+
+def _build_index_raw() -> list[dict]:
+    """Pull the full A-share (code, name) table via akshare. Raises if akshare unavailable."""
+    if ak is None:
+        return []
+    # stock_info_a_code_name: ~5000 rows, ~100KB. Returns cols ['code', 'name'] (lowercase).
+    df = ak.stock_info_a_code_name()
+    if df is None or df.empty:
+        return []
+    # Robust to column naming variants.
+    code_col = "code" if "code" in df.columns else df.columns[0]
+    name_col = "name" if "name" in df.columns else df.columns[1]
+    return [
+        {"code": str(row[code_col]).zfill(6), "name": str(row[name_col])}
+        for _, row in df.iterrows()
+        if row[name_col]
+    ]
+
+
+def build_a_share_index() -> list[dict]:
+    """Cached wrapper — index is static enough for 7-day TTL."""
+    return cached("_global", "a_share_name_index", _build_index_raw, ttl=TTL_STATIC)
+
+
+# ═══════════════════════════════════════════════════════════════
+# Public API
+# ═══════════════════════════════════════════════════════════════
+
+def fuzzy_match(
+    query: str,
+    top_k: int = 5,
+    max_distance: int = 2,
+    min_jaccard: float = 0.6,
+) -> list[dict]:
+    """Find closest A-share names to `query`.
+
+    Args:
+        query: user input (Chinese name, possibly with character-order typo)
+        top_k: return at most this many candidates
+        max_distance: maximum allowed Levenshtein distance
+        min_jaccard: pre-filter threshold (characters must overlap)
+
+    Returns:
+        list of {"code", "name", "distance", "jaccard"} sorted by (distance asc, jaccard desc).
+        Empty list if index unavailable or no candidate within threshold.
+    """
+    query = query.strip()
+    if not query:
+        return []
+
+    index = build_a_share_index()
+    if not index:
+        return []
+
+    # Stage 1: cheap Jaccard pre-filter
+    # Use a slightly looser threshold for 2-char queries (they can't overlap much).
+    eff_jaccard = min_jaccard if len(query) >= 3 else 0.5
+    shortlist: list[tuple[dict, float]] = []
+    for entry in index:
+        j = char_set_jaccard(query, entry["name"])
+        if j >= eff_jaccard:
+            shortlist.append((entry, j))
+
+    if not shortlist:
+        return []
+
+    # Stage 2: Levenshtein ranking
+    scored: list[dict] = []
+    for entry, j in shortlist:
+        d = levenshtein(query, entry["name"])
+        if d <= max_distance:
+            scored.append({
+                "code": entry["code"],
+                "name": entry["name"],
+                "distance": d,
+                "jaccard": round(j, 3),
+            })
+
+    scored.sort(key=lambda x: (x["distance"], -x["jaccard"]))
+    return scored[:top_k]
+
+
+if __name__ == "__main__":
+    import json
+    import sys
+    q = sys.argv[1] if len(sys.argv) > 1 else "北部港湾"
+    hits = fuzzy_match(q)
+    print(f"Query: {q}")
+    print(json.dumps(hits, ensure_ascii=False, indent=2))

--- a/skills/deep-analysis/scripts/run_real_test.py
+++ b/skills/deep-analysis/scripts/run_real_test.py
@@ -1007,6 +1007,21 @@ def stage2(ticker: str) -> str:
         print(f"   panel_insights: {'✓' if agent_analysis.get('panel_insights') else '✗'}")
         print(f"   narrative_override: {'✓' if agent_analysis.get('narrative_override') else '✗'}")
         print(f"   great_divide_override: {'✓' if agent_analysis.get('great_divide_override') else '✗'}")
+
+        # v2.4 · HARD-GATE-QUALITATIVE 校验（仅警示，不 abort）
+        qd = agent_analysis.get("qualitative_deep_dive") or {}
+        required_dims = ("3_macro", "7_industry", "8_materials", "9_futures", "13_policy", "15_events")
+        missing_qd = [d for d in required_dims if d not in qd or not qd[d].get("evidence")]
+        total_evidence = sum(len((qd.get(d) or {}).get("evidence") or []) for d in required_dims)
+        total_assoc = sum(len((qd.get(d) or {}).get("associations") or []) for d in required_dims)
+        if missing_qd:
+            print(f"   ⚠️  qualitative_deep_dive: 缺失 {len(missing_qd)}/6 维 ({','.join(missing_qd)})")
+            print(f"      → 参考 references/task2.5-qualitative-deep-dive.md")
+            print(f"      → 应 spawn 3 个并行 sub-agent (Macro-Policy / Industry-Events / Cost-Transmission)")
+        else:
+            print(f"   qualitative_deep_dive: ✓ 6 维全覆盖 · evidence {total_evidence} 条 · associations {total_assoc} 条")
+            if total_assoc < 3:
+                print(f"   ⚠️  跨域因果链仅 {total_assoc} 条，task2.5 要求 ≥ 3 条")
     else:
         print(f"\n⚠️  未检测到 agent_analysis.json · 将使用脚本骨架生成 synthesis")
         print(f"   提示: Claude agent 应在 stage1 之后写入 .cache/{ti.full}/agent_analysis.json")

--- a/skills/deep-analysis/scripts/run_real_test.py
+++ b/skills/deep-analysis/scripts/run_real_test.py
@@ -835,17 +835,41 @@ def stage1(ticker: str) -> dict:
     Claude 应该在 stage1 之后介入，用 sub-agent 逐组分析 51 评委，
     覆盖 panel.json 中的 headline/reasoning/score，然后调 stage2 生成报告。
     """
-    # v2.2 · 中文名自动解析: "北部港湾" → "000582.SZ"
+    # v2.3 · 中文名解析 — 支持纠错提示。若输入无法明确解析，早退并返回候选，不继续跑 22 fetcher。
     from lib.market_router import is_chinese_name
+    ti = None
     if is_chinese_name(ticker):
         try:
             from lib import data_sources as _ds
-            resolved = _ds.resolve_chinese_name(ticker)
-            if resolved:
-                print(f"  [resolve] {ticker} → {resolved.full}")
-                ti = resolved
+            r = _ds.resolve_chinese_name_rich(ticker)
+            if r["resolved"] is not None:
+                if r["source"] != "exact":
+                    print(f"  [resolve] {ticker} → {r['resolved'].full} (via {r['source']})")
+                ti = r["resolved"]
+            elif r["candidates"]:
+                # Early-exit with structured suggestions. Write a marker so run.py / agent can react.
+                import json as _json
+                from pathlib import Path as _Path
+                safe_dir = _Path(".cache") / ticker
+                safe_dir.mkdir(parents=True, exist_ok=True)
+                err_payload = {
+                    "status": "name_not_resolved",
+                    "user_input": ticker,
+                    "candidates": r["candidates"],
+                    "message": f"未能确认 '{ticker}' 对应的股票。最接近的候选: "
+                               + ", ".join(f"{c['name']}({c['code']})" for c in r["candidates"][:3]),
+                }
+                (safe_dir / "_resolve_error.json").write_text(
+                    _json.dumps(err_payload, ensure_ascii=False, indent=2), encoding="utf-8"
+                )
+                print(f"\n🔴 无法确认股票: {ticker!r}")
+                print(f"   你是不是想输入：")
+                for c in r["candidates"][:5]:
+                    print(f"     · {c['name']} ({c['code']})   [编辑距离 {c['distance']}]")
+                print(f"   请用 --force-name <代码> 指定，或用准确名称/代码重跑。")
+                return err_payload
             else:
-                ti = parse_ticker(ticker)
+                ti = parse_ticker(ticker)  # last resort, will likely fail fetcher
         except Exception:
             ti = parse_ticker(ticker)
     else:
@@ -859,12 +883,43 @@ def stage1(ticker: str) -> dict:
     write_task_output(ti.full, "raw_data", raw)
 
     # Data integrity check
-    from lib.data_integrity import validate as _validate_raw, format_report as _fmt_integrity
+    from lib.data_integrity import (
+        validate as _validate_raw,
+        format_report as _fmt_integrity,
+        generate_recovery_tasks as _gen_tasks,
+    )
     _integrity = _validate_raw(raw)
     print("\n" + _fmt_integrity(_integrity))
     raw["_integrity"] = _integrity
-    if _integrity["critical_missing"]:
-        print("  ⚠️  Task 1 有关键字段缺失，下游评估可能不准确")
+
+    # v2.3 · 生成可被 agent 消费的恢复任务清单（不 abort，让 agent 接管补数据）
+    _tasks = _gen_tasks(raw, _integrity)
+    if _tasks:
+        import json as _json
+        from pathlib import Path as _Path
+        gaps_path = _Path(".cache") / ti.full / "_data_gaps.json"
+        gaps_path.parent.mkdir(parents=True, exist_ok=True)
+        gaps_path.write_text(
+            _json.dumps({
+                "ticker": ti.full,
+                "coverage_pct": _integrity.get("coverage_pct", 0),
+                "critical_missing": _integrity.get("critical_missing", False),
+                "tasks": _tasks,
+            }, ensure_ascii=False, indent=2),
+            encoding="utf-8",
+        )
+        crit_n = sum(1 for t in _tasks if t["severity"] == "critical")
+        print(f"\n{'▓' * 50}")
+        print(f"⚠️  检测到 {len(_tasks)} 个数据缺口 ({crit_n} critical)")
+        print(f"   恢复任务清单: .cache/{ti.full}/_data_gaps.json")
+        print(f"   Agent 必须尝试用以下手段补齐（按优先级）:")
+        print(f"     1. Chrome/Playwright MCP 访问 xueqiu/eastmoney")
+        print(f"     2. MX API (若 MX_APIKEY 已设置)")
+        print(f"     3. WebSearch 精确到代码")
+        print(f"     4. 已有数据逻辑推导")
+        print(f"   仍拿不到的字段 → 在 agent_analysis.json 显式标 data_gap_acknowledged")
+        print(f"   HTML 报告会对这些字段显示 ⚠️ 橙色徽章而非假数据")
+        print(f"{'▓' * 50}")
 
     print("\n🏛  Task 1.5 · 机构级财务建模 (Dims 20-22)")
     from compute_deep_methods import compute_dim_20, compute_dim_21, compute_dim_22
@@ -960,6 +1015,34 @@ def stage2(ticker: str) -> str:
 
     print(f"\n⚖ Task 4 · 综合研判")
     syn = generate_synthesis(raw, dims, panel, agent_analysis=agent_analysis)
+
+    # v2.3 · 合并 _data_gaps.json 进 synthesis，让报告组装环节能渲染橙色徽章/banner。
+    # agent 若在 agent_analysis.json 里显式 ack 了某个 gap，标 resolved=false + note；
+    # 其他未处理的 gap 原样传递给 HTML。
+    from pathlib import Path as _Path
+    import json as _json
+    gaps_path = _Path(".cache") / ti.full / "_data_gaps.json"
+    if gaps_path.exists():
+        try:
+            gaps_doc = _json.loads(gaps_path.read_text(encoding="utf-8"))
+            tasks = gaps_doc.get("tasks", [])
+            # Merge agent's ack if present
+            acks = (agent_analysis or {}).get("data_gap_acknowledged", {}) if agent_analysis else {}
+            for t in tasks:
+                key = f"{t['dim']}.{t['field']}"
+                if key in acks or t["dim"] in acks:
+                    t["status"] = "acknowledged"
+                    t["agent_note"] = acks.get(key, acks.get(t["dim"], ""))
+            syn["data_gaps"] = {
+                "coverage_pct": gaps_doc.get("coverage_pct", 0),
+                "total_gaps": len(tasks),
+                "unresolved": sum(1 for t in tasks if t["status"] == "pending"),
+                "tasks": tasks,
+            }
+            print(f"  data_gaps: {syn['data_gaps']['total_gaps']} 项 · 已 ack {syn['data_gaps']['total_gaps'] - syn['data_gaps']['unresolved']}")
+        except Exception as _e:
+            print(f"  ⚠️ 读取 _data_gaps.json 失败: {_e}")
+
     write_task_output(ti.full, "synthesis", syn)
     print(f"  综合评分: {syn['overall_score']}/100 · {syn['verdict_label']}")
     print(f"  agent_reviewed: {syn.get('agent_reviewed', False)}")
@@ -1012,7 +1095,11 @@ def main(ticker: str = "002273.SZ"):
         # ... agent 审查 panel.json, 写 agent_analysis.json ...
         stage2(ticker)            # 生成报告 (自动合并 agent_analysis)
     """
-    stage1(ticker)
+    result = stage1(ticker)
+    # v2.3 · stage1 可能因中文名无法解析而早退，此时不能继续 stage2
+    if isinstance(result, dict) and result.get("status") == "name_not_resolved":
+        print("\n⚠️  因股票名无法解析，跳过 stage2（不会生成空报告）")
+        return
     report_path = stage2(ticker)
     print(f"\n🎯 完整流程结束 · 报告: {report_path}")
 


### PR DESCRIPTION
## Summary

两批改动，4 个独立 commit，分别对应 v2.3 和 v2.4 版本主题。

### v2.3 · 数据采集稳定性
- **名字纠错**：用户输入 "北部港湾"（typo）可被自动识别为 "北部湾港" (000582.SZ)。三层解析：MX 妙想 API → akshare 精确 → 本地 Levenshtein fuzzy
- **东财妙想 API 接入**：新 `lib/mx_api.py` 官方 Skills Hub 客户端，通过 `MX_APIKEY` env 启用（可选，无 key 时回退到现有链）
- **数据缺口 agent 接管**：stage1 生成 `_data_gaps.json` 恢复任务清单；HTML 报告顶部显示橙色 banner + 缺失字段 chip；agent 可用 `data_gap_acknowledged` 标注"真的拿不到"
- **两条 HARD-GATE**（`SKILL.md`）：HARD-GATE-NAME + HARD-GATE-DATAGAPS

### v2.4 · 报告质量
- **大佬抓作业放全**：移除 `fetch_fund_holders.py` 的 limit=50 硬顶（茅台实测 995 家持有 → 649 家主动权益全部收录）。前 6 位大卡 + 第 7 位起紧凑行（48px × 滚动）。并行计算提速
- **6 维定性深度方法论**：新增 `references/task2.5-qualitative-deep-dive.md`（~400 行），含 3 agent 分工（Macro-Policy / Industry-Events / Cost-Transmission）、每维 4-7 必答问题、6 条跨域因果链、每维 Browser/MCP URL 模板、结构化输出 schema
- **HARD-GATE-QUALITATIVE**：强制 3 并行 sub-agent，禁止爬虫片段直接当 commentary

## Commits（按 bisect 友好粒度拆分）

1. `636064e` **feat(v2.3)**: 中文名纠错 + 东方财富妙想官方 API 接入
2. `7fb963b` **feat(v2.3)**: agent-driven data gap recovery + HTML banner + HARD-GATEs
3. `b6b9636` **fix(v2.4)**: 大佬抓作业完整性 + 紧凑行展开模式
4. `de22f8f` **docs(v2.4)**: 6 维定性深度分析方法论 + HARD-GATE-QUALITATIVE

## 效果对比（"北部港湾" typo 场景）

| | 修复前 | 修复后 |
|---|---|---|
| 名字解析 | 直接当 code 下发，22 fetcher 全炸 | MX 一步命中 / 本地 fuzzy 返回候选 |
| Coverage | 17% (3/18) | 94% (17/18) |
| name / price / industry / market_cap | 全 null | 北部湾港 / 10.73 / 港口航运 / 270.1亿 |
| DCF intrinsic | ¥0（空数据）| ¥11.54 · 安全边际 7.5% |
| 51 评委共识 | 35.4%（幻觉）| 真信号 12/19/19 |

## 茅台抓作业实测
- total_funds_holding: 995
- active_funds_count: **649 全部收录**（旧版只能看到 top 50）
- 排序：按 5Y 累计收益 DESC（最高中庚价值领航 +136.2%）

## Test plan

- [ ] `.env.example` 按指引 `cp .env.example .env` + 填 MX_APIKEY
- [ ] `python3 run.py 北部港湾` → 有 MX 自动映射为 000582.SZ，无 MX 时返回候选列表
- [ ] `python3 run.py 贵州茅台 --no-browser` → 报告里看到 "✨ 649 位公募基金经理"，展开按钮文案 "展开剩余 643 位（按 5Y 收益排名）▼"
- [ ] `.env` 未被 tracked（`git ls-files .env` 为空）
- [ ] 代码里无 key 硬编码（`grep -r "mkt_" --include="*.py"` 为空）
- [ ] agent 跑一次完整流程后查 `.cache/{ticker}/agent_analysis.json` 含 `qualitative_deep_dive.{3-15}` 6 维

## 安全说明

- `MX_APIKEY` 通过 `.env` 文件（已 gitignore）或 shell export 传入
- 无 API key 的用户零感知，自动走现有 XueQiu/akshare 链
- 所有改动对外 API 兼容（旧调用者仍能用 `resolve_chinese_name()` 薄壳）

🤖 Generated with [Claude Code](https://claude.com/claude-code)