### PR TITLE
v2.9.2 · ETF/LOF/可转债 识别 + 交互式引导到成分股

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "stock-deep-analyzer",
-  "version": "2.9.1",
+  "version": "2.9.2",
   "description": "A股/港股/美股个股深度分析引擎 · 22维数据 × 51位大佬量化评委 × 17种机构级分析方法 · 杀猪盘检测 · Bloomberg风格HTML报告 | A-share / HK / US stock deep-analysis with first-class Chinese-market coverage — 22 data dims × 51-investor jury × 17 institutional methods · trap detection · Bloomberg-style HTML report",
   "author": {
     "name": "FloatFu-true",

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "stock-deep-analyzer",
   "description": "A股/港股/美股个股深度分析引擎 · 22维数据 × 51位大佬量化评委 · 17种机构级分析方法 | A-share / HK / US deep-analysis · 22 dims × 51-investor jury × 17 institutional methods",
-  "version": "2.9.1",
+  "version": "2.9.2",
   "author": {
     "name": "FloatFu-true"
   },

--- a/.version-bump.json
+++ b/.version-bump.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.9.1",
+  "version": "2.9.2",
   "files": [
     ".claude-plugin/plugin.json",
     ".cursor-plugin/plugin.json",

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,5 +1,88 @@
 # Release Notes
 
+## v2.9.2 — 2026-04-17 (ETF/LOF/可转债 识别 + 交互式引导到成分股)
+
+> **用户反馈：分析 `512400`（沪市有色金属 ETF）被错判为 SZ，全盘网络+数据错误；且即便修正也不该跑——51 评委是个股规则，ETF 没 ROE/护城河这些字段**
+
+### 2 个 BUG + 1 个新功能
+
+### BUG#1 · Ticker 识别错（512400 → SZ 错的）
+
+`lib/market_router.py::_a_share_suffix` 旧规则：
+
+```python
+if code6.startswith(("60", "688", "900")): return "SH"
+if code6.startswith(("83", "87", "88", "92")): return "BJ"
+return "SZ"   # 其他所有 6 位码全归 SZ
+```
+
+导致所有**沪市 ETF (5xxxxx) / 沪市可转债 (10/11xxxx)** 被错判 SZ，eastmoney
+`secid` 前缀变 `0.` 应该是 `1.` → 所有 API 全返错。
+
+**修法**：重写 `_a_share_suffix` 覆盖完整规则：
+- SH：600/601/603/605/606... · 688（科创板股票）· 900（B 股）· 50/51/52/56/58（基金）· 10/11（可转债）
+- BJ：83/87/88/92
+- SZ：其他（000/001/002/003/300/301/159/16/18/12...）
+
+### BUG#2 · ETF/LOF/可转债 混进个股流程
+
+即便 ticker 识别正确，**这些非个股标的就根本不该走 51 评委 + 22 维流程**：
+- ETF 没有 ROE / 护城河 / 管理层
+- 可转债看的是转股价 / 溢价率 / YTM
+- 基金看的是基金经理 / 规模 / 回撤
+
+**修法**：新 `classify_security_type(code6)` 识别 stock / etf / lof / convertible_bond。`fetch_basic` + `stage1` 两层早退：
+- fetch_basic 返 `error: non_stock_security`
+- stage1 早退 + 写 `_resolve_error.json`（格式同 name_not_resolved）
+
+### 新功能 · ETF 交互式引导
+
+**用户要求**："如果检测到是 etf，则告知客户这个插件对 etf 无法支持，但可以帮助他识别前十大持仓股，然后列出股票，询问他需要识别哪一只？"
+
+已落地：
+
+```
+🔴 非个股标的: 512400.SH (ETF)
+   本插件是个股深度分析引擎，51 评委跑 ROE/护城河/管理层/分红 这些个股财务指标，ETF 没这些字段
+
+   📊 不过我可以帮你识别 512400.SH 的前 10 大持仓，请选一只分析：
+
+      1. 紫金矿业     (601899.SH  ) · 占比 12.50%
+      2. 洛阳钼业     (603993.SH  ) · 占比  9.80%
+      3. 赣锋锂业     (002460.SZ  ) · 占比  8.21%
+      ...
+
+   👉 请选择要分析的成分股（告诉我编号或代码）
+      例：/analyze-stock 601899.SH  或  /analyze-stock 紫金矿业
+```
+
+同时写 `_resolve_error.json` 带 `top_holdings: [{rank, code, name, weight_pct}, ...]` + `user_prompt` 字段，agent 读到就知道走 ETF 引导流程。
+
+### SKILL.md 新增 HARD-GATE-NON-STOCK
+
+规定 agent 看到 `status: non_stock_security` 必须：
+- 绝不假装跑；用 AskUserQuestion 列 top_holdings 让用户选
+- 用户选定后用成分股代码重跑 stage1
+
+### 回归测试（51/51 · 新增 6 条）
+
+- `test_ticker_parser_sh_etf` · 512400/510500/513100/518880/588000 全部 SH
+- `test_ticker_parser_sz_etf` · 159949/159922/159928 全部 SZ
+- `test_ticker_parser_convertible_bonds` · 11xxxx SH + 12xxxx SZ
+- `test_ticker_parser_stocks_still_correct` · 个股识别不受影响
+- `test_fetch_basic_rejects_etf` · fetch_basic 必须接 classify_security_type
+- `test_stage1_early_exits_on_etf` · stage1 必须早退 + 输出 top_holdings
+
+### 改动文件
+
+- `scripts/lib/market_router.py` · 重写 `_a_share_suffix` + 新 `classify_security_type`
+- `scripts/fetch_basic.py` · ETF/LOF/CB 早退 + `_NON_STOCK_GUIDANCE` 表
+- `scripts/run_real_test.py::stage1` · 早退 + 拉前 10 持仓 + 互动 prompt
+- `skills/deep-analysis/SKILL.md` · 新 HARD-GATE-NON-STOCK
+- `scripts/tests/test_no_regressions.py` · +6 条
+
+---
+
 ## v2.9.1 — 2026-04-17 (评委汇总观点 · 6 处 bug 修复)
 
 > **用户反馈："评委打分了，但是汇总评委观点那里存在缺失和数据不对的问题"**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stock-deep-analyzer",
-  "version": "2.9.1",
+  "version": "2.9.2",
   "description": "A股/港股/美股个股深度分析引擎 · 22维数据 × 51位大佬量化评委 · 17种机构级分析方法 | A-share / HK / US deep-analysis · 22 dims × 51-investor jury × 17 institutional methods",
   "type": "module",
   "author": "FloatFu-true",

--- a/skills/deep-analysis/SKILL.md
+++ b/skills/deep-analysis/SKILL.md
@@ -46,6 +46,47 @@ description: 个股深度分析的核心工作流。当用户要求"深度分析
 唯一例外：用户原话含"自动选最相近的"或明确说"就是 Top1" — 此时可以不问
 </HARD-GATE>
 
+### ⛔ HARD-GATE-NON-STOCK · ETF/LOF/可转债 必须引导到成分股（v2.9.2）
+
+<HARD-GATE>
+若 `stage1()` 返回 `{"status": "non_stock_security", "security_type": "etf|lof|convertible_bond", ...}`
+（或 `.cache/{ticker}/_resolve_error.json` 有 `status: non_stock_security`），
+你**绝不能**假装继续跑——51 评委规则全是个股财务指标，ETF/基金/可转债
+根本不该走这个 pipeline。
+
+你必须：
+
+1. 读 `_resolve_error.json`，拿 `label` / `why` / `top_holdings`
+2. **向用户明确说明**："本插件是**个股**深度分析引擎，{label} 未覆盖"
+3. **若是 ETF**（`top_holdings` 非空）：
+   - 列出前 10 大持仓（已在 payload 里）：rank / name / code / weight_pct
+   - 用 `AskUserQuestion` 问："你想分析 ETF 里的哪只成分股？"
+   - 用户选定后用**成分股代码**（如 `601899.SH`）重跑 `stage1()`
+4. **若是 LOF 基金**：告知"基金评估用专门工具，本插件只分析个股"
+5. **若是可转债**：建议"分析正股或用集思录可转债工具"
+
+**绝不能**：
+- 硬把 ETF 跑完 stage1（22 维大多 N/A）
+- 虚构"ETF 评委意见"（51 评委从没为 ETF 设计过规则）
+- 看到 `_resolve_error.json` 就忽略继续调 stage2
+
+Payload 示例（agent 看到这个就知道该走 ETF 引导流程）:
+```json
+{
+  "status": "non_stock_security",
+  "security_type": "etf",
+  "ticker": "512400.SH",
+  "label": "ETF",
+  "top_holdings": [
+    {"rank": 1, "code": "601899.SH", "name": "紫金矿业", "weight_pct": 12.5},
+    {"rank": 2, "code": "603993.SH", "name": "洛阳钼业", "weight_pct": 9.8},
+    ...
+  ],
+  "user_prompt": "请选择要分析的成分股（输入编号或代码）"
+}
+```
+</HARD-GATE>
+
 ### ⛔ HARD-GATE-QUALITATIVE · 6 维定性维度必须 agent 深度分析（v2.4）
 
 <HARD-GATE>

--- a/skills/deep-analysis/scripts/fetch_basic.py
+++ b/skills/deep-analysis/scripts/fetch_basic.py
@@ -13,7 +13,26 @@ import json
 import sys
 
 from lib import data_sources as ds
-from lib.market_router import is_chinese_name, parse_ticker
+from lib.market_router import is_chinese_name, parse_ticker, classify_security_type
+
+
+_NON_STOCK_GUIDANCE = {
+    "etf": {
+        "label": "ETF",
+        "why": "插件的 51 评委跑 ROE / 护城河 / 管理层 / 分红 等个股财务指标，ETF 没这些字段",
+        "what_to_do": "分析该 ETF 的**前 3-5 大持仓股**（ak.fund_portfolio_hold_em 可查），对每只成分股单独跑 /analyze-stock",
+    },
+    "lof": {
+        "label": "LOF 基金",
+        "why": "基金没有企业基本面字段，不适合 51 评委流程",
+        "what_to_do": "基金评估应看：基金经理 / 规模 / 持仓集中度 / 业绩基准差 / 回撤；这些该用 /fund-analyze 类工具（本插件未覆盖）",
+    },
+    "convertible_bond": {
+        "label": "可转债",
+        "why": "可转债评估看的是转股价 / 溢价率 / 到期收益率 / 赎回条款，不是 ROE",
+        "what_to_do": "集思录的可转债工具 / 东财可转债专题；或直接分析**正股**",
+    },
+}
 
 
 def main(user_input: str) -> dict:
@@ -34,6 +53,26 @@ def main(user_input: str) -> dict:
         ti = r["resolved"]
     else:
         ti = parse_ticker(user_input)
+
+    # v2.9.2 · 早期拦截 ETF/LOF/可转债（插件是个股分析引擎，跑非个股标的会输出垃圾）
+    sec_type = classify_security_type(ti.code) if ti.market == "A" else "stock"
+    if sec_type in _NON_STOCK_GUIDANCE:
+        g = _NON_STOCK_GUIDANCE[sec_type]
+        return {
+            "ticker": ti.full,
+            "market": ti.market,
+            "data": {},
+            "error": "non_stock_security",
+            "security_type": sec_type,
+            "guidance": g,
+            "message": (
+                f"{ti.full} 是 {g['label']}，不是个股。\n"
+                f"原因: {g['why']}\n"
+                f"建议: {g['what_to_do']}"
+            ),
+            "source": "market_router:classify_security_type",
+            "fallback": True,
+        }
 
     data = ds.fetch_basic(ti)
     return {

--- a/skills/deep-analysis/scripts/lib/market_router.py
+++ b/skills/deep-analysis/scripts/lib/market_router.py
@@ -1,4 +1,8 @@
-"""Identify market (A / H / U) from a ticker or stock name and normalize the code."""
+"""Identify market (A / H / U) from a ticker or stock name and normalize the code.
+
+v2.9.2 · 扩展 `_a_share_suffix` 覆盖 ETF / LOF / 可转债 等非个股 6 位码
+        + 增加 `classify_security_type` 识别标的类型（stock/etf/lof/cb）
+"""
 from __future__ import annotations
 
 import re
@@ -6,6 +10,7 @@ from dataclasses import dataclass
 from typing import Literal
 
 Market = Literal["A", "H", "U"]
+SecurityType = Literal["stock", "etf", "lof", "convertible_bond", "unknown"]
 
 
 @dataclass
@@ -22,13 +27,98 @@ _RE_HK = re.compile(r"^(\d{4,5})(?:\.HK)?$", re.I)
 _RE_US = re.compile(r"^[A-Z][A-Z\.\-]{0,5}$")
 
 
+# ═══════════════════════════════════════════════════════════════
+# v2.9.2 · 完整的 6 位码分类（之前只看前 2 位，漏了一大片）
+# ═══════════════════════════════════════════════════════════════
+# 沪市 (SH)：
+#   600xxx / 601xxx / 603xxx / 605xxx · 主板股票
+#   688xxx · 科创板股票
+#   900xxx · B 股
+#   50xxxx / 51xxxx / 52xxxx / 56xxxx / 58xxxx · ETF
+#   501xxx / 502xxx / 506xxx · LOF（部分重叠 ETF 范围，逻辑上同属 SH 基金）
+#   10xxxx / 11xxxx · 可转债
+#
+# 深市 (SZ)：
+#   000xxx / 001xxx / 002xxx / 003xxx · 主板 / 中小板股票
+#   300xxx · 创业板股票
+#   159xxx · ETF
+#   160xxx / 161xxx / 162xxx / 163xxx / 164xxx / 165xxx / 166xxx / 167xxx / 168xxx · LOF
+#   12xxxx / 127xxx / 128xxx · 可转债
+#
+# 北交所 (BJ)：
+#   83xxxx / 87xxxx / 88xxxx / 92xxxx
+
+_SH_PREFIXES_2 = ("60", "68", "90")       # 688 涉及在 _SH_3 里单独覆盖
+_SH_STOCK_PREFIXES_3 = ("688",)
+_SH_B_SHARE = ("900",)
+_SH_FUND_PREFIXES_2 = ("50", "51", "52", "56", "58")
+_SH_BOND_PREFIXES_2 = ("10", "11")
+
+_SZ_STOCK_PREFIXES_3 = ("000", "001", "002", "003", "300", "301")
+_SZ_FUND_PREFIXES_3 = ("159",)
+_SZ_LOF_PREFIXES_2 = ("16",)  # 160xxx-168xxx
+_SZ_BOND_PREFIXES_2 = ("12",)
+
+_BJ_PREFIXES_2 = ("83", "87", "88", "92")
+
+
 def _a_share_suffix(code6: str) -> str:
-    """Decide SZ/SH/BJ for a 6-digit A-share code."""
-    if code6.startswith(("60", "688", "900")):
-        return "SH"
-    if code6.startswith(("83", "87", "88", "92")):
+    """Decide SZ/SH/BJ for a 6-digit A-share code.
+
+    v2.9.2 修复：之前只看前 2 位 (60/688/900 → SH, 其他 → SZ)，导致：
+      - 512400 (SH ETF) 被错判 SZ
+      - 10xxxx / 11xxxx (SH 可转债) 被错判 SZ
+      - 159xxx (SZ ETF) 虽然默认 SZ 对了但巧合
+    现在按完整规则走，任何 6 位码都能归对交易所。
+    """
+    # 北交所
+    if code6.startswith(_BJ_PREFIXES_2):
         return "BJ"
-    return "SZ"  # 000/001/002/003/300
+    # 沪市（按优先级：股票 → ETF/LOF/可转债）
+    if code6.startswith(_SH_STOCK_PREFIXES_3):    # 688xxx 科创板
+        return "SH"
+    if code6.startswith(_SH_B_SHARE):              # 900xxx B 股
+        return "SH"
+    if code6.startswith(("60",)):                  # 600/601/603/605/606...
+        return "SH"
+    if code6.startswith(_SH_FUND_PREFIXES_2):      # 50/51/52/56/58 · SH ETF/LOF
+        return "SH"
+    if code6.startswith(_SH_BOND_PREFIXES_2):      # 10/11 · SH 可转债
+        return "SH"
+    # 深市（包含其他所有剩余 6 位码）
+    return "SZ"
+
+
+def classify_security_type(code6: str) -> SecurityType:
+    """v2.9.2 新增：识别标的类型（stock / etf / lof / convertible_bond）.
+
+    用于 fetch_basic 早期拒绝非个股标的（插件设计为个股分析，ETF/可转债
+    没有 ROE / 护城河 / 管理层等字段，不适合跑 51 评委流程）。
+    """
+    if not code6 or not code6.isdigit() or len(code6) != 6:
+        return "unknown"
+    # ETF
+    if code6.startswith(_SZ_FUND_PREFIXES_3) or \
+       code6.startswith(_SH_FUND_PREFIXES_2):
+        # SH 50/51/52/56/58 中，501/502/506 部分是 LOF，其他是 ETF
+        if code6.startswith(("501", "502", "506")):
+            return "lof"
+        return "etf"
+    # SZ LOF (160xxx-168xxx)
+    if code6.startswith(_SZ_LOF_PREFIXES_2):
+        return "lof"
+    # 可转债
+    if code6.startswith(_SH_BOND_PREFIXES_2) or \
+       code6.startswith(_SZ_BOND_PREFIXES_2):
+        return "convertible_bond"
+    # 股票
+    if code6.startswith(_SH_STOCK_PREFIXES_3) or \
+       code6.startswith(_SH_B_SHARE) or \
+       code6.startswith(("60",)) or \
+       code6.startswith(_SZ_STOCK_PREFIXES_3) or \
+       code6.startswith(_BJ_PREFIXES_2):
+        return "stock"
+    return "unknown"
 
 
 def parse_ticker(raw: str) -> TickerInfo:

--- a/skills/deep-analysis/scripts/run_real_test.py
+++ b/skills/deep-analysis/scripts/run_real_test.py
@@ -1459,6 +1459,98 @@ def stage1(ticker: str) -> dict:
     print(f"🎯 TARGET: {ti.full}")
     print(f"━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\n")
 
+    # v2.9.2 · 早期拦截 ETF / LOF / 可转债（非个股不适合 51 评委流程）
+    # 跟 name_not_resolved 一样的处理：写 _resolve_error.json + return
+    if ti.market == "A":
+        try:
+            from lib.market_router import classify_security_type
+            sec_type = classify_security_type(ti.code)
+            NON_STOCK_GUIDANCE = {
+                "etf": ("ETF", "51 评委跑 ROE / 护城河 / 管理层 / 分红 这些个股财务指标，ETF 没这些字段",
+                        "建议：分析该 ETF 前 3-5 大持仓股（用 akshare.fund_portfolio_hold_em 查持仓），对每只成分股单独跑 /analyze-stock"),
+                "lof": ("LOF 基金", "基金没有企业基本面字段", "基金评估用专门的 fund-analyze 工具"),
+                "convertible_bond": ("可转债", "可转债看转股价/溢价率/到期收益率，不是 ROE", "分析正股或用集思录的可转债工具"),
+            }
+            if sec_type in NON_STOCK_GUIDANCE:
+                label, why, what_to_do = NON_STOCK_GUIDANCE[sec_type]
+                import json as _json
+                from pathlib import Path as _Path
+                safe_dir = _Path(".cache") / ti.full
+                safe_dir.mkdir(parents=True, exist_ok=True)
+
+                # v2.9.2 · ETF 特殊处理：拉前 10 大持仓供用户选择
+                top_holdings: list[dict] = []
+                if sec_type == "etf":
+                    try:
+                        import akshare as ak
+                        df = ak.fund_portfolio_hold_em(symbol=ti.code)
+                        if df is not None and not df.empty:
+                            # 找最新一期（通常按日期倒序）
+                            if "季度" in df.columns:
+                                latest_period = df["季度"].iloc[0]
+                                df_latest = df[df["季度"] == latest_period]
+                            else:
+                                df_latest = df
+                            for i, (_, row) in enumerate(df_latest.head(10).iterrows(), start=1):
+                                stock_code = str(row.get("股票代码", "") or row.get("code", "") or "").strip()
+                                stock_name = str(row.get("股票名称", "") or row.get("name", "") or "").strip()
+                                pct_raw = row.get("占净值比例") or row.get("比例") or row.get("weight") or ""
+                                try:
+                                    pct = float(str(pct_raw).replace("%", "")) if pct_raw else 0
+                                except (ValueError, TypeError):
+                                    pct = 0
+                                if stock_code and stock_name:
+                                    # 标准化股票代码：补交易所后缀
+                                    try:
+                                        _ti_stock = parse_ticker(stock_code)
+                                        full_code = _ti_stock.full
+                                    except Exception:
+                                        full_code = stock_code
+                                    top_holdings.append({
+                                        "rank": i,
+                                        "code": full_code,
+                                        "name": stock_name,
+                                        "weight_pct": round(pct, 2) if pct else None,
+                                    })
+                    except Exception as _e:
+                        print(f"  ⚠️ 拉 ETF 持仓失败: {type(_e).__name__}: {str(_e)[:80]}")
+
+                err_payload = {
+                    "status": "non_stock_security",
+                    "security_type": sec_type,
+                    "ticker": ti.full,
+                    "label": label,
+                    "why": why,
+                    "what_to_do": what_to_do,
+                    "top_holdings": top_holdings,  # ETF 才填
+                    "message": (
+                        f"{ti.full} 是 {label}，不是个股 — 本插件未设计支持这类标的。\n"
+                        f"原因: {why}\n"
+                        f"{what_to_do}"
+                    ),
+                    "user_prompt": (
+                        "请选择要分析的成分股（输入编号或代码），例如：`/analyze-stock 1` 或 `/analyze-stock 601899`"
+                        if top_holdings else ""
+                    ),
+                }
+                (safe_dir / "_resolve_error.json").write_text(
+                    _json.dumps(err_payload, ensure_ascii=False, indent=2), encoding="utf-8"
+                )
+                print(f"\n🔴 非个股标的: {ti.full} ({label})")
+                print(f"   本插件是**个股**深度分析引擎，{why}")
+                if sec_type == "etf" and top_holdings:
+                    print(f"\n   📊 不过我可以帮你识别 {ti.full} 的前 {len(top_holdings)} 大持仓，请选一只分析：\n")
+                    for h in top_holdings:
+                        pct_str = f"{h['weight_pct']:.2f}%" if h.get("weight_pct") else "—"
+                        print(f"     {h['rank']:2d}. {h['name']:12} ({h['code']:12}) · 占比 {pct_str}")
+                    print(f"\n   👉 请选择要分析的成分股（告诉我编号或代码）")
+                    print(f"      例：/analyze-stock {top_holdings[0]['code']}  或  /analyze-stock {top_holdings[0]['name']}")
+                else:
+                    print(f"   {what_to_do}")
+                return err_payload
+        except Exception as e:
+            print(f"  ⚠️ 非个股检测出错，继续走正常流程: {type(e).__name__}: {str(e)[:80]}")
+
     print("📊 Task 1 · 数据采集")
     raw = collect_raw_data(ti.full)
     write_task_output(ti.full, "raw_data", raw)

--- a/skills/deep-analysis/scripts/tests/test_no_regressions.py
+++ b/skills/deep-analysis/scripts/tests/test_no_regressions.py
@@ -572,6 +572,79 @@ def test_debate_no_hardcoded_default_avatars():
         "v2.9.1 regression: BEAR_ID 默认值不能硬编码 graham"
 
 
+# ─── v2.9.2 · ETF/LOF/可转债 识别与早期拦截 ──
+def test_ticker_parser_sh_etf():
+    """BUG (v2.9.2) · 512400 是 SH ETF，不能被错判为 SZ"""
+    from lib.market_router import parse_ticker, classify_security_type
+    # 用户报告的核心 case
+    ti = parse_ticker("512400")
+    assert ti.full == "512400.SH", f"BUG#2.9.2 regression: 512400 应为 SH，实际 {ti.full!r}"
+    assert classify_security_type(ti.code) == "etf"
+    # 其他 SH ETF
+    for code in ("510500", "513100", "518880", "588000"):
+        ti = parse_ticker(code)
+        assert ti.full.endswith(".SH"), f"{code} 应为 SH，实际 {ti.full}"
+
+
+def test_ticker_parser_sz_etf():
+    from lib.market_router import parse_ticker, classify_security_type
+    for code in ("159949", "159922", "159928"):
+        ti = parse_ticker(code)
+        assert ti.full.endswith(".SZ"), f"{code} 应为 SZ"
+        assert classify_security_type(ti.code) == "etf"
+
+
+def test_ticker_parser_convertible_bonds():
+    from lib.market_router import parse_ticker, classify_security_type
+    # SH 可转债 11xxxx
+    ti = parse_ticker("113517")
+    assert ti.full.endswith(".SH")
+    assert classify_security_type(ti.code) == "convertible_bond"
+    # SZ 可转债 12xxxx
+    ti = parse_ticker("123029")
+    assert ti.full.endswith(".SZ")
+    assert classify_security_type(ti.code) == "convertible_bond"
+
+
+def test_ticker_parser_stocks_still_correct():
+    """修复 ETF 识别的同时不能破坏股票识别"""
+    from lib.market_router import parse_ticker, classify_security_type
+    for code, expected in [
+        ("600519", ".SH"),   # 茅台
+        ("688981", ".SH"),   # 中芯国际 科创板
+        ("000807", ".SZ"),   # 云铝
+        ("300750", ".SZ"),   # 宁德
+        ("301000", ".SZ"),   # 创业板注册制
+        ("830799", ".BJ"),   # 北交所
+    ]:
+        ti = parse_ticker(code)
+        assert ti.full.endswith(expected), f"{code} 应为 {expected}，实际 {ti.full}"
+        assert classify_security_type(ti.code) == "stock"
+
+
+def test_fetch_basic_rejects_etf():
+    """v2.9.2 · fetch_basic 必须在看到 ETF ticker 时早期返回 non_stock_security"""
+    src = (SCRIPTS_DIR / "fetch_basic.py").read_text(encoding="utf-8")
+    assert "classify_security_type" in src, \
+        "v2.9.2 regression: fetch_basic 未接入 classify_security_type"
+    assert "non_stock_security" in src, \
+        "v2.9.2 regression: fetch_basic 缺 non_stock_security 错误类型"
+    assert "NON_STOCK_GUIDANCE" in src or "_NON_STOCK_GUIDANCE" in src, \
+        "v2.9.2 regression: fetch_basic 缺 ETF/LOF/CB 引导信息表"
+
+
+def test_stage1_early_exits_on_etf():
+    """v2.9.2 · run_real_test.stage1 必须在 ETF ticker 时早期 return，
+    不跑 22 维 fetcher 浪费时间"""
+    src = (SCRIPTS_DIR / "run_real_test.py").read_text(encoding="utf-8")
+    assert "non_stock_security" in src, \
+        "v2.9.2 regression: stage1 缺 non_stock_security 早退逻辑"
+    assert "top_holdings" in src, \
+        "v2.9.2 regression: ETF 早退必须输出 top_holdings 供用户选择"
+    assert "fund_portfolio_hold_em" in src, \
+        "v2.9.2 regression: ETF 持仓拉取接口未使用"
+
+
 if __name__ == "__main__":
     # Manual runner — no pytest required
     import inspect


### PR DESCRIPTION
## 用户反馈
\`512400\` 沪市有色金属 ETF 分析时：
1. Ticker 错判 SZ（应该 SH），eastmoney secid 前缀全错
2. 即便修正也不该跑 —— ETF 没 ROE/护城河这些个股字段

## 修复

### BUG#1 · \`_a_share_suffix\` 规则不全
覆盖完整 SH/SZ/BJ 规则，512400 / 11xxxx / 10xxxx 等 ETF 和可转债都能正确识别。

### BUG#2 · ETF/LOF/可转债 不该跑个股流程
新 \`classify_security_type()\` + \`fetch_basic\` / \`stage1\` 两层早退。

### 新功能 · ETF 交互式引导（用户要求）
检测到 ETF → 自动拉前 10 大持仓 → 列编号 → 问用户选哪只分析

\`\`\`
🔴 非个股标的: 512400.SH (ETF)
   📊 前 10 大持仓（请选一只分析）:
      1. 紫金矿业 (601899.SH) · 占比 12.50%
      2. 洛阳钼业 (603993.SH) · 占比 9.80%
      ...
   👉 /analyze-stock 601899.SH 或 /analyze-stock 紫金矿业
\`\`\`

## Test plan
- [x] 51/51 regression tests pass（新增 6 条）
- [x] 512400 → SH/etf ✓
- [x] 113517 → SH/convertible_bond ✓
- [x] 个股识别（688981/000807/830799 等）不受影响