### PR TITLE
v2.10.3 · 多源 providers + 三档深度 + 网络韧性 + README 三档说明

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "stock-deep-analyzer",
-  "version": "2.9.2",
+  "version": "2.10.3",
   "description": "A股/港股/美股个股深度分析引擎 · 22维数据 × 51位大佬量化评委 × 17种机构级分析方法 · 杀猪盘检测 · Bloomberg风格HTML报告 | A-share / HK / US stock deep-analysis with first-class Chinese-market coverage — 22 data dims × 51-investor jury × 17 institutional methods · trap detection · Bloomberg-style HTML report",
   "author": {
     "name": "FloatFu-true",

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "stock-deep-analyzer",
   "description": "A股/港股/美股个股深度分析引擎 · 22维数据 × 51位大佬量化评委 · 17种机构级分析方法 | A-share / HK / US deep-analysis · 22 dims × 51-investor jury × 17 institutional methods",
-  "version": "2.9.2",
+  "version": "2.10.3",
   "author": {
     "name": "FloatFu-true"
   },

--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,6 @@ docs/screenshots/full-page.png
 # Local-only drafts (not for remote)
 docs/wechat-article.md
 docs/*.local.md
+
+# v2.10.2 · prewarm_cache 生成的预热数据（release 附件，不进 repo）
+skills/deep-analysis/scripts/prewarm/

--- a/.version-bump.json
+++ b/.version-bump.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.9.2",
+  "version": "2.10.3",
   "files": [
     ".claude-plugin/plugin.json",
     ".cursor-plugin/plugin.json",

--- a/README.md
+++ b/README.md
@@ -180,6 +180,65 @@ agent 会自动用 `--remote` 启动 Cloudflare Tunnel，给你一个 `https://x
 
 ---
 
+## 🎚️ 三档思考深度（v2.10.3 新增）
+
+给用户自己选择分析力度——快想 / 正常 / 深挖：
+
+```bash
+python run.py 600519 --depth lite     # ⚡ 速判模式（1-2 分钟）
+python run.py 600519                   # 📊 标准分析（5-8 分钟）· 默认
+python run.py 600519 --depth deep      # 🔬 深度研究（15-20 分钟）
+```
+
+或通过环境变量：
+
+```bash
+export UZI_DEPTH=lite       # 或 medium / deep
+python run.py 600519
+```
+
+### 三档差异一览
+
+| 维度 | ⚡ **lite** 速判 | 📊 **medium** 标准 | 🔬 **deep** 机构级 |
+|---|---|---|---|
+| **预计耗时** | 1-2 分钟 | 5-8 分钟 | 15-20 分钟 |
+| **fetcher 维度** | 核心 7 维 | 全 22 维 | 全 22 维 + 强化 fallback |
+| **评委数量** | 10 位代表 | 51 位完整 | 51 位 + **Bull-Bear 结构化辩论** |
+| **机构方法** | 只 DCF | 全 17 种 | 全 17 种 + **Segmental Build-Up** |
+| **ddgs 定性查询** | **全 skip**（省 token）| 按需 · 预算 30 次 | 跑满 · 预算 60 次 |
+| **fund_holders** | Top 5 完整业绩 | Top 20 完整 + 其余清单 | Top 100 完整 |
+| **自查 gate** | critical block | critical block · warning 可 ack | 两级都 block |
+| **Token 消耗（Codex）** | 最省 | 中等 | 最大 |
+| **适用场景** | 随手看 / 老板临时问 / 预判 ETF 成分股 | 日常深度分析 · 写研报 | 投委会备忘录 · 建仓前深挖 |
+
+### 自动降级策略
+
+- **第一次安装** / `.cache/_global` 空时 → 自动切 lite（省首次冷启动时间）
+- **网络预检 3+ 域不通** → 自动切 lite（避免卡死）
+- 手动 `--depth` 始终覆盖自动判定
+
+### 实战选择
+
+| 问题 | 推荐档位 |
+|---|---|
+| "帮我看看这只票能不能买" | `medium`（默认） |
+| "15 分钟内给我个结论" | `lite` |
+| "老板明天投委会要看" | `deep`（含 Bull-Bear 辩论 + bottom-up segmental） |
+| "ETF 代码输进去了（系统会提示选成分股）" | `lite`（成分股快速预判）|
+| "Codex 环境 / 首次安装" | 不用管 · 自动 lite |
+
+### 命令映射（隐式档位）
+
+| 命令 | 隐式档位 |
+|---|---|
+| `/quick-scan 600519` | lite |
+| `/panel-only 600519` | lite |
+| `/analyze-stock 600519` | medium（默认）|
+| `/ic-memo 600519` | deep |
+| `/initiate 600519` | deep |
+
+---
+
 ## 🎭 51 位评审团
 
 不是模板话术。每个人有自己的**量化规则集**（共 180 条），给出的建议必须引用具体命中了哪条：

--- a/README_EN.md
+++ b/README_EN.md
@@ -179,6 +179,65 @@ The agent spins up a Cloudflare Tunnel and gives you a `https://xxx.trycloudflar
 
 ---
 
+## 🎚️ Three Analysis Depths (new in v2.10.3)
+
+Let users pick how much thinking they want — quick / standard / deep-dive:
+
+```bash
+python run.py 600519 --depth lite     # ⚡ Quick read (1-2 min)
+python run.py 600519                    # 📊 Standard (5-8 min) · default
+python run.py 600519 --depth deep       # 🔬 Institutional (15-20 min)
+```
+
+Or via env var:
+
+```bash
+export UZI_DEPTH=lite       # or medium / deep
+python run.py 600519
+```
+
+### Differences
+
+| Aspect | ⚡ **lite** | 📊 **medium** | 🔬 **deep** |
+|---|---|---|---|
+| **Runtime** | 1-2 min | 5-8 min | 15-20 min |
+| **Fetchers** | Core 7 dims | All 22 dims | All 22 + reinforced fallback |
+| **Investors** | 10 representatives | 51 full panel | 51 + **Bull-Bear structured debate** |
+| **Institutional methods** | DCF only | All 17 | All 17 + **Segmental Build-Up** |
+| **ddgs qualitative queries** | **all skipped** (saves tokens) | on-demand · budget 30 | full throttle · budget 60 |
+| **fund_holders** | Top 5 with full 5Y stats | Top 20 full + rest as listing | Top 100 full |
+| **Self-review gate** | critical blocks | critical blocks · warning ack-able | both block |
+| **Token cost (Codex)** | minimal | moderate | maximum |
+| **Use case** | Quick glance · boss just asked · preview ETF holdings | Daily deep analysis · writing research | Investment committee memo · pre-position deep dive |
+
+### Auto-downgrade
+
+- **First install** / empty `.cache/_global` → auto-switches to lite (saves cold-start time)
+- **Network preflight 3+ domains unreachable** → auto lite (prevents hanging)
+- Manual `--depth` always overrides auto-detection
+
+### Picking the right depth
+
+| Question | Recommended |
+|---|---|
+| "Can I buy this stock?" | `medium` (default) |
+| "Give me a verdict in 15 minutes" | `lite` |
+| "Prepping for investment committee tomorrow" | `deep` (includes Bull-Bear debate + bottom-up segmental) |
+| "I typed an ETF code — system asked me to pick a holding" | `lite` (quick verdict on component) |
+| "Codex environment / first install" | Don't worry — auto lite |
+
+### Implicit depth per command
+
+| Command | Implicit depth |
+|---|---|
+| `/quick-scan 600519` | lite |
+| `/panel-only 600519` | lite |
+| `/analyze-stock 600519` | medium (default) |
+| `/ic-memo 600519` | deep |
+| `/initiate 600519` | deep |
+
+---
+
 ## 🎭 51 Investor Jury
 
 Not template phrases. Each investor has their own **quantified rule set** (180 rules total) + their own **real quoted voice** + their own **authentic decision profile** (time horizon / position sizing / what-would-change-my-mind).

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,5 +1,99 @@
 # Release Notes
 
+## v2.10.3 — 2026-04-18 (多源 providers 框架 + 三档深度 + 网络韧性)
+
+> **一次性合入近一天积累的所有性能 / 韧性 / 数据源改造**
+
+### 用户反馈驱动的 6 大改动
+
+**1. 三档思考深度（用户："让用户自己选择思考深度"）**
+- `lite` (1-2min) / `medium` (5-8min · 默认) / `deep` (15-20min)
+- `--depth` CLI arg 或 `UZI_DEPTH` env
+- 三档差异清晰对比（fetcher 维度 / 评委数 / 机构方法 / ddgs 预算 / fund_holders 策略 / 自查严格度）
+- 命令隐式档位 (`/quick-scan` → lite · `/ic-memo` → deep)
+
+**2. Multi-Provider 框架（用户："除了 akshare，tushare 这些能作为备选吗"）**
+  - `lib/providers/` Protocol + chain builder
+  - 5 个内置 provider: akshare / efinance / tushare / baostock / **direct_http**
+  - `get_provider_chain(dim, market)` 按优先级 failover
+  - `UZI_PROVIDERS_<DIM>` 单维度覆盖
+
+**3. direct_http provider（用户转达 Codex 建议 fetch_web_quote.py）**
+  - Codex 声称做了但实际未提交；我来落地
+  - 腾讯 qt.gtimg.cn / 新浪 hq.sinajs.cn / etnet.com.hk
+  - 3 级 fallback · 覆盖 A/H/U 三市场
+  - 实测 600519/000001/00700/AAPL 全部拿到实时价
+  - 脱离 akshare，GFW 风险减半
+
+**4. Fund holders 双层策略（用户："基金拉全不是直接检索就行了吗"）**
+  - 原先 649 家每家 2 次 akshare (算 5Y NAV) = 1300 API 串行跑 5-10 分钟
+  - 新：Top N 家 full 业绩 + 其余 lite 清单（0 额外 API）
+  - `UZI_FUND_STATS_TOP=N` 调节 (lite=5, medium=20, deep=100)
+  - 30-60 秒出结果
+
+**5. 代理/网络韧性（用户："代理、网络不通导致 codex 卡死"）**
+  - `lib/net_timeout_guard` monkey-patch requests 默认 `UZI_HTTP_TIMEOUT=20`
+  - `lib/web_search._ddg_search` 线程池硬 timeout `UZI_DDG_TIMEOUT=10`
+  - `lib/network_preflight` 启动 TCP 探 5 个关键域，3+ 不通自动切 lite
+  - parse_ticker 修复 3 位数字识别为 HK (`700` → `00700.HK`)
+  - Codex + 代理挂最坏耗时: 40 分钟 → 30-60 秒
+
+**6. prewarm cache 脚本（用户："缓存能提前写入吗，别含敏感信息"）**
+  - `scripts/prewarm_cache.py` 只跑公开数据
+  - 输出 `prewarm/api_cache/` (gitignored)
+  - sanity_check_output 扫描 sk-/@qq.com/Users/ 模式报警
+  - 可打 tar.gz 作 release 附件分发
+
+### 底层技术改动
+
+| 新增 | 作用 |
+|---|---|
+| `lib/providers/` (5 文件) | 多源自动 failover 框架 |
+| `lib/analysis_profile.py` | 三档 depth profile 定义 |
+| `lib/net_timeout_guard.py` | 全局 requests timeout |
+| `lib/network_preflight.py` | 启动预检 |
+| `scripts/prewarm_cache.py` | 预热 cache 生成器 |
+| `docs/DATA-PROVIDERS.md` | 25+ 数据源全景清单 |
+
+### 改动文件
+
+- `run.py` · 加 `--depth` arg · 加载 profile
+- `run_real_test.py::stage1` · 自动 lite 检测 · 预检 · timeout guard 导入 · fetcher 按 profile 过滤
+- `fetch_fund_holders.py` · 双层 full/lite
+- `fetch_industry.py` · lite mode skip dynamic
+- `lib/web_search.py` · ddgs timeout + 预算
+- `lib/market_router.py` · HK 3 位数字修复
+- `assemble_report.py::render_fund_managers` · lite row 友好显示
+- `README.md` / `README_EN.md` · 三档深度新章节
+
+### 回归
+
+**68/68** regression tests pass
+新增 13 条:
+- test_fund_holders_two_tier_strategy
+- test_lite_mode_detection_exists
+- test_ddg_budget_enforced
+- test_fetch_industry_respects_lite_mode
+- test_analysis_profile_three_tiers
+- test_analysis_profile_env_compat
+- test_prewarm_cache_script_exists
+- test_ddg_timeout_wrapper
+- test_net_timeout_guard_exists
+- test_network_preflight_exists
+- test_parse_ticker_hk_3digit
+- test_providers_framework_loads + chain_failover + env_override + health_check + tushare_requires_key + direct_http_provider
+
+### 性能对比
+
+| 场景 | v2.9.2 | v2.10.3 |
+|---|---|---|
+| 首次安装 + 正常网络 | 10-15 分钟 | 2-4 分钟 (medium) |
+| 首次安装 + 代理挂 | 30-40 分钟卡死 | 30-60 秒 (自动 lite) |
+| `--depth lite` | — | 1-2 分钟 |
+| `--depth deep` | — | 15-20 分钟 |
+
+---
+
 ## v2.9.2 — 2026-04-17 (ETF/LOF/可转债 识别 + 交互式引导到成分股)
 
 > **用户反馈：分析 `512400`（沪市有色金属 ETF）被错判为 SZ，全盘网络+数据错误；且即便修正也不该跑——51 评委是个股规则，ETF 没 ROE/护城河这些字段**

--- a/docs/DATA-PROVIDERS.md
+++ b/docs/DATA-PROVIDERS.md
@@ -1,0 +1,159 @@
+# 数据源 Providers 指南
+
+UZI-Skill 采用多数据源 + 自动 failover 架构 (v2.10.3 起)。本文档列出**所有能接入**的 providers 及配置方法。
+
+## 优先级模型
+
+每个 fetcher 请求时，按这个顺序尝试：
+
+```
+主源 akshare (0 key, 默认)
+  ↓ 挂了
+并行冗余 efinance (0 key, pip install efinance)
+  ↓ 挂了
+官方 API tushare (需 TUSHARE_TOKEN)
+  ↓ 挂了
+兜底 baostock (0 key, 已装)
+```
+
+可用 `UZI_PROVIDERS_<DIM>` 覆盖单维度优先级，如：
+```bash
+# 财务数据强制优先走 tushare（忽略 akshare）
+export UZI_PROVIDERS_FINANCIALS=tushare,akshare
+```
+
+## 已实现的 Providers
+
+### 🟢 `akshare` · 零配置主源
+
+**状态**: 已随 `requirements.txt` 安装
+**特色**: 覆盖最广（A/港/美股 + 基金 + 期货 + 宏观）
+**限制**: 爬虫聚合，字段偶有不稳；GFW 代理时挂
+
+### 🟢 `baostock` · 零配置兜底
+
+**状态**: 已随 `requirements.txt` 安装
+**特色**: 官方合作，A 股历史财报 + K 线稳定
+**限制**: 仅 A 股 · 需要 `login()`
+
+### 🟡 `efinance` · 零 key 并行冗余（推荐装）
+
+**启用**:
+```bash
+pip install efinance
+```
+
+**特色**:
+- 内部走东财 + 同花顺 + 新浪聚合爬虫
+- 国内网络稳定性 ≥ akshare
+- 覆盖 A/港/美股 + ETF + 基金 + 可转债
+- 与 akshare 字段格式不同，作为失败冗余
+
+**建议**: akshare 冷启动慢 / 代理不通时，efinance 常能救场
+
+### 🟡 `tushare` · 官方 API（推荐注册）
+
+**启用**:
+```bash
+# 1. 访问 https://tushare.pro 注册（免费 120 积分）
+# 2. 个人中心 → 接口 TOKEN 复制
+pip install tushare
+export TUSHARE_TOKEN=your_token_here
+```
+
+**特色**:
+- **字段质量最高** · ISO 清洗流程 · 官方授权
+- **财报深度 5-10 年** · 利润表 / 资产负债表 / 现金流 三表齐全
+- **机构级衍生数据** · 龙虎榜席位细节 / 北向实时 / 期货逐笔
+- **国内网络稳定** · 走 tushare.pro HTTPS（不是 GFW 风险路径）
+
+**限制**: 免费 120 积分够跑 50 次左右；常用接口需 2000+ 分（贡献数据 / 充值）
+
+## 未实现但国内能用的 Providers
+
+按 ROI 排，想加随时欢迎 PR：
+
+### 零 key · 开源库
+
+| Provider | pip 包 | 覆盖 | 亮点 |
+|---|---|---|---|
+| **adata** | `pip install adata` | A 股多源聚合 | 新兴开源，国内稳 |
+| **AkTools HTTP** | `pip install aktools` | 同 akshare | HTTP 网关模式，可做远程共享 cache |
+| **stockstats** | `pip install stockstats` | 技术指标 | 计算库，不是数据源 |
+
+### 需要账号 · 券商 OpenAPI（免费）
+
+| Provider | 账号条件 | 特色 |
+|---|---|---|
+| **富途 Futu OpenAPI** | 富途开户 | 港美股 + A 股实时 L2 盘口 |
+| **长桥 Longbridge OpenAPI** | 长桥开户 | 港美股 · SDK 免费 |
+| **老虎 Tiger API** | 老虎开户 | 美股为主 |
+| **华泰 iQuant** | 华泰开户 | A 股量化环境 |
+
+### 需要账号 · 研究平台（免费额度）
+
+| Provider | 免费额度 | 特色 |
+|---|---|---|
+| **聚宽 JQData** | 100 次/日 | A 股研究，本地跑 |
+| **米筐 RiceQuant** | 200 次/日 | 覆盖期货期权 |
+| **QuantAxis** | 本地部署 | 量化框架 · 自建数据源 |
+
+### 境外 · 美股专用（代理/VPN 才能用）
+
+| Provider | 免费配额 | 特色 |
+|---|---|---|
+| **Financial Modeling Prep** | 250 次/日 | 美股 5 年财报 + 隐含 DCF |
+| **Alpha Vantage** | 500 次/日 | 美股实时 + 技术指标 + 外汇 |
+| **Polygon.io** | 5 次/分钟（历史） | 美股 tick-level |
+| **OpenBB Platform** | 自身整合 10+ 源 | Python SDK `openbb` |
+| **stooq.com** | 无限（直连 HTTP） | 美股/欧股日级历史 |
+
+### 付费（不默认接，用户有授权时可自接）
+
+Wind / 万得 · Choice · iFinD · Bloomberg · Refinitiv — 价钱不合理
+
+## Health Check
+
+查看当前所有 provider 的可用性：
+
+```bash
+cd skills/deep-analysis/scripts
+python -c "from lib import providers; import json; print(json.dumps(providers.health_check(), ensure_ascii=False, indent=2))"
+```
+
+输出示例：
+```json
+{
+  "akshare":  {"available": true,  "markets": ["A","H","U"], "requires_key": false, "status": "ok"},
+  "efinance": {"available": false, "status": "unavailable"},
+  "tushare":  {"available": false, "markets": ["A"], "requires_key": true, "status": "unavailable"},
+  "baostock": {"available": true,  "markets": ["A"], "requires_key": false, "status": "ok"}
+}
+```
+
+## 建议配置（国内用户）
+
+**极简**（默认）：
+```
+akshare + baostock + DDGS
+```
+
+**标准**（推荐）：
+```bash
+pip install efinance
+# akshare + efinance + baostock（+ DDGS）
+```
+
+**最稳**：
+```bash
+pip install efinance tushare
+export TUSHARE_TOKEN=xxx
+# 四层冗余，GFW 挂也能跑
+```
+
+**含境外**（需代理）：
+```bash
+pip install efinance tushare openbb
+export TUSHARE_TOKEN=xxx
+export FMP_API_KEY=xxx
+```

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stock-deep-analyzer",
-  "version": "2.9.2",
+  "version": "2.10.3",
   "description": "A股/港股/美股个股深度分析引擎 · 22维数据 × 51位大佬量化评委 · 17种机构级分析方法 | A-share / HK / US deep-analysis · 22 dims × 51-investor jury × 17 institutional methods",
   "type": "module",
   "author": "FloatFu-true",

--- a/run.py
+++ b/run.py
@@ -250,7 +250,19 @@ def main():
                         help="v2.6 · 强制重抓所有 fetcher（默认 resume：复用 .cache/{ticker}/raw_data.json 已有维度）")
     parser.add_argument("--enable-xueqiu-login", action="store_true",
                         help="v2.7.1 · 启用 XueQiu Playwright 登录态抓取实盘比赛持仓（首次需 `python -m lib.xueqiu_browser login`）")
+    parser.add_argument("--depth", choices=["lite", "medium", "deep"], default=None,
+                        help="v2.10.2 · 思考深度 · lite(1-2min) / medium(5-8min · 默认) / deep(15-20min · 含 Bull-Bear 辩论 + Segmental)")
     args = parser.parse_args()
+
+    # v2.10.2 · 深度选择（优先级: --depth > UZI_DEPTH env > UZI_LITE env > 默认 medium）
+    try:
+        sys.path.insert(0, str(Path(__file__).parent / "skills" / "deep-analysis" / "scripts"))
+        from lib.analysis_profile import get_profile, apply_profile_to_env, format_banner
+        profile = get_profile(args.depth) if args.depth else get_profile()
+        apply_profile_to_env(profile)
+        print(f"\n{format_banner(profile)}\n")
+    except Exception as _e:
+        print(f"⚠️ 无法加载 analysis_profile: {_e}")
 
     # v2.3 · --force-name 直接覆盖
     if args.force_name:

--- a/skills/deep-analysis/scripts/assemble_report.py
+++ b/skills/deep-analysis/scripts/assemble_report.py
@@ -1809,8 +1809,17 @@ def render_fund_managers(managers: list) -> str:
     if not managers:
         return '<div style="padding:24px;text-align:center;color:#94a3b8;font-size:12px">暂无公募基金持仓数据</div>'
 
-    # Sort by 5Y return desc
-    managers_sorted = sorted(managers, key=lambda m: m.get("return_5y", 0), reverse=True)
+    # v2.10.1 · 分 full / lite 两类：full 有 5Y 业绩在前按 5Y 降序，lite 在后按持仓%
+    def _sort_key(m: dict) -> tuple:
+        is_full = m.get("_row_type") == "full" or m.get("return_5y") is not None
+        ret5y = m.get("return_5y") if is_full else 0
+        pos = m.get("position_pct") or 0
+        return (
+            0 if is_full else 1,
+            -(ret5y if isinstance(ret5y, (int, float)) else 0),
+            -pos,
+        )
+    managers_sorted = sorted(managers, key=_sort_key)
     cards = []
     for m in managers_sorted:
         name = m.get("name", "—")
@@ -1891,7 +1900,17 @@ def render_fund_managers(managers: list) -> str:
 </div>'''
         cards.append(card)
 
-    header = f'<div class="fund-mgr-header">✨ <strong>{len(managers)} 位公募基金经理</strong>持有本股 · 按 5 年累计收益排序 · 你可以直接"抄作业"</div>'
+    # v2.10.1 · 头部与清单分开统计
+    full_count = sum(1 for m in managers if m.get("_row_type") == "full" or m.get("return_5y") is not None)
+    lite_count = len(managers) - full_count
+    if lite_count > 0:
+        header = (
+            f'<div class="fund-mgr-header">✨ <strong>{len(managers)} 家公募基金</strong>持有本股 · '
+            f'头部 <strong>{full_count}</strong> 家有完整 5Y 业绩（按收益排序），'
+            f'其余 <strong>{lite_count}</strong> 家按持仓占比列出（点基金链接看详情）</div>'
+        )
+    else:
+        header = f'<div class="fund-mgr-header">✨ <strong>{len(managers)} 位公募基金经理</strong>持有本股 · 按 5 年累计收益排序 · 你可以直接"抄作业"</div>'
 
     INITIAL_SHOW = 6
     if len(cards) <= INITIAL_SHOW:
@@ -1931,19 +1950,17 @@ def render_fund_managers(managers: list) -> str:
 def _render_fund_compact_row(m: dict, rank: int) -> str:
     """One-line strip for fund managers ranked 7+. Used in expanded compact list.
 
-    Reuses color/percentile logic from render_fund_managers so styling stays in sync.
+    v2.10.1: lite 行（return_5y is None）显示持仓占比 + "点击看详情"，
+    不再硬编码 "前 50%" 同类排名这种假数据。
     """
+    is_lite = m.get("_row_type") == "lite" or m.get("return_5y") is None
     name = m.get("name", "—")
     fund_name = m.get("fund_name", "—")
     fund_code = m.get("fund_code", "")
     avatar = m.get("avatar", "")
-    ret_5y = m.get("return_5y", 0) or 0
-    peer_rank = m.get("peer_rank_pct", 50) or 50
+    position_pct = m.get("position_pct") or 0
 
-    ret_color = COLOR_BULL if ret_5y > 0 else COLOR_BEAR
-    rank_color = COLOR_BULL if peer_rank < 20 else COLOR_GOLD if peer_rank < 50 else COLOR_BEAR
-
-    # rank badge: top 3 gold, 4-10 silver, rest plain
+    # rank badge
     if rank <= 3:
         badge_style = "background:linear-gradient(135deg,#f59e0b,#d97706);color:#fff"
     elif rank <= 10:
@@ -1954,20 +1971,39 @@ def _render_fund_compact_row(m: dict, rank: int) -> str:
     if avatar:
         avatar_html = f'<img src="avatars/{avatar}.svg" class="fc-avatar" alt="">'
     else:
-        avatar_html = f'<div class="fc-avatar fc-avatar-ph">{name[0] if name else "?"}</div>'
+        avatar_html = f'<div class="fc-avatar fc-avatar-ph">{(name[0] if name and name != "—" else "?")}</div>'
 
     fund_url = m.get("fund_url", f"https://fund.eastmoney.com/{fund_code}.html")
-    sign = "+" if ret_5y > 0 else ""
+
+    if is_lite:
+        # Lite 行：不展示 5Y 业绩，给一个"点进去看"的提示
+        metric_html = (
+            f'<span class="fc-return" style="color:#94a3b8;font-style:italic">持仓 {position_pct:.2f}%</span>'
+            f'<span class="fc-rank-pct" style="color:#94a3b8;font-size:10px">点→查业绩</span>'
+        )
+        name_display = fund_name  # lite 行没基金经理名，直接显示基金名
+        fund_display = f"代码 {fund_code}"
+    else:
+        ret_5y = m.get("return_5y") or 0
+        peer_rank = m.get("peer_rank_pct") or 50
+        ret_color = COLOR_BULL if ret_5y > 0 else COLOR_BEAR
+        rank_color = COLOR_BULL if peer_rank < 20 else COLOR_GOLD if peer_rank < 50 else COLOR_BEAR
+        sign = "+" if ret_5y > 0 else ""
+        metric_html = (
+            f'<span class="fc-return" style="color:{ret_color}">{sign}{ret_5y:.1f}%</span>'
+            f'<span class="fc-rank-pct" style="color:{rank_color}">前 {peer_rank}%</span>'
+        )
+        name_display = name
+        fund_display = fund_name
 
     return f'''<div class="fund-compact-row">
   <span class="fc-rank" style="{badge_style}">{rank}</span>
   {avatar_html}
   <div class="fc-info">
-    <div class="fc-name">{name}</div>
-    <div class="fc-fund">{fund_name}</div>
+    <div class="fc-name">{name_display}</div>
+    <div class="fc-fund">{fund_display}</div>
   </div>
-  <span class="fc-return" style="color:{ret_color}">{sign}{ret_5y:.1f}%</span>
-  <span class="fc-rank-pct" style="color:{rank_color}">前 {peer_rank}%</span>
+  {metric_html}
   <a href="{fund_url}" target="_blank" rel="noopener" class="fc-link" title="查看基金详情">→</a>
 </div>'''
 

--- a/skills/deep-analysis/scripts/fetch_fund_holders.py
+++ b/skills/deep-analysis/scripts/fetch_fund_holders.py
@@ -251,10 +251,26 @@ def main(ticker: str, limit: int | None = None) -> dict:
 
     active_holders = [h for h in holders if "error" not in h and _is_active_fund(h.get("基金名称", ""))]
     total_funds = len([h for h in holders if "error" not in h])
-    iter_holders = active_holders if limit is None else active_holders[:limit]
 
-    # v2.4 · 并行计算每个基金的 5Y 统计（以前 100+ 基金串行跑约 30s）
-    def _build_row(row: dict) -> dict | None:
+    # v2.10.1 · 双层策略（用户反馈：基金清单一次就能拿全，没必要每家都算 5Y 业绩）
+    #   · Top N 家（按持仓金额排序）算完整 5Y 业绩（sharpe/回撤/回报）
+    #   · 其余家只列清单（名字 + 持仓% + 基金链接）
+    # 这样 649 家 × 每家 2 API ≈ 1300 次 → 缩到 20 × 2 = 40 次 API
+    # 用户想看某家 5Y 业绩，点 fund_url 到东财看
+    import os as _os
+    stats_top_n = int(_os.environ.get("UZI_FUND_STATS_TOP", "20"))
+
+    # 按持仓金额/比例降序，保证头部大票仓位的拿到完整业绩
+    def _pos_pct(h: dict) -> float:
+        try:
+            return float(h.get("占市值比例", 0) or h.get("占流通股比例", 0))
+        except (ValueError, TypeError):
+            return 0.0
+    sorted_holders = sorted(active_holders, key=_pos_pct, reverse=True)
+    iter_holders = sorted_holders if limit is None else sorted_holders[:limit]
+
+    def _build_row_full(row: dict) -> dict | None:
+        """完整版：算 5Y 业绩 + 查基金经理（2 次 akshare API）"""
         fund_code = str(row.get("基金代码", ""))
         fund_name = str(row.get("基金名称", ""))
         if not fund_code:
@@ -283,18 +299,50 @@ def main(ticker: str, limit: int | None = None) -> dict:
             "peer_rank_pct": 50,
             "nav_history": stats.get("nav_history", []),
             "fund_url": f"https://fund.eastmoney.com/{fund_code}.html",
+            "_row_type": "full",
         }
 
-    # 并行度默认 1（serial）— Py3.13 下 akshare 内部 mini_racer/libffi 并发会致命崩溃。
-    # 设置 UZI_FUND_WORKERS=N (N>1) 强制并行（自担 V8 isolate crash 风险）。
-    # BUG#v2.4-followup: 默认 3 在 Py3.13 + macOS 下 fund_portfolio_hold_em 也会崩。
-    import os as _os
+    def _build_row_lite(row: dict) -> dict | None:
+        """轻量版：只用 holders 数据，0 次 API 额外调用"""
+        fund_code = str(row.get("基金代码", ""))
+        fund_name = str(row.get("基金名称", ""))
+        if not fund_code:
+            return None
+        try:
+            position_pct = float(row.get("占市值比例", 0) or row.get("占流通股比例", 0))
+        except (ValueError, TypeError):
+            position_pct = 0.0
+        return {
+            "name": "—",   # 不查基金经理名
+            "fund_name": fund_name,
+            "fund_code": fund_code,
+            "avatar": "",
+            "position_pct": round(position_pct, 2),
+            "rank_in_fund": 0,
+            "holding_quarters": 1,
+            "position_trend": "持有",
+            "return_5y": None,
+            "annualized_5y": None,
+            "max_drawdown": None,
+            "sharpe": None,
+            "peer_rank_pct": None,
+            "nav_history": [],
+            "fund_url": f"https://fund.eastmoney.com/{fund_code}.html",
+            "_row_type": "lite",
+        }
+
+    # 分两组：头部 top_n 走 full，其余走 lite
+    top_full = iter_holders[:stats_top_n]
+    rest_lite = iter_holders[stats_top_n:]
+
     _workers = int(_os.environ.get("UZI_FUND_WORKERS", "1"))
     managers: list[dict] = []
+
+    # Top N · 完整版（2 次 API/家）
     if _workers <= 1:
-        for row in iter_holders:
+        for row in top_full:
             try:
-                r = _build_row(row)
+                r = _build_row_full(row)
                 if r is not None:
                     managers.append(r)
             except Exception:
@@ -302,7 +350,7 @@ def main(ticker: str, limit: int | None = None) -> dict:
     else:
         from concurrent.futures import ThreadPoolExecutor, as_completed
         with ThreadPoolExecutor(max_workers=_workers) as pool:
-            futures = [pool.submit(_build_row, row) for row in iter_holders]
+            futures = [pool.submit(_build_row_full, row) for row in top_full]
             for fut in as_completed(futures):
                 try:
                     r = fut.result()
@@ -311,8 +359,26 @@ def main(ticker: str, limit: int | None = None) -> dict:
                 except Exception:
                     continue
 
-    # Sort by 5Y return
-    managers.sort(key=lambda m: m.get("return_5y", 0), reverse=True)
+    # 其余 · 轻量版（0 次 API/家 · 纯清单）
+    lite_count = 0
+    for row in rest_lite:
+        try:
+            r = _build_row_lite(row)
+            if r is not None:
+                managers.append(r)
+                lite_count += 1
+        except Exception:
+            continue
+
+    # Sort: full 行有 return_5y 排前面，lite 行按持仓占比排在后面
+    def _sort_key(m: dict) -> tuple:
+        is_full = m.get("_row_type") == "full"
+        return (
+            0 if is_full else 1,                            # full 在前
+            -(m.get("return_5y") or 0) if is_full else 0,   # full 内按 5Y 降序
+            -(m.get("position_pct") or 0),                  # lite 内按持仓降序
+        )
+    managers.sort(key=_sort_key)
 
     passive_count = max(0, total_funds - len(active_holders))
     return {
@@ -320,15 +386,19 @@ def main(ticker: str, limit: int | None = None) -> dict:
         "data": {
             "fund_managers": managers,
             "total_funds_holding": total_funds,
-            "active_funds_count": len(managers),
+            "active_funds_count": len(active_holders),
+            "full_stats_count": len(top_full),
+            "lite_count": lite_count,
             "passive_funds_filtered": passive_count,
             "_note": (
-                f"共 {total_funds} 家基金持有本股 · "
-                f"收录 {len(managers)} 家主动权益基金（已按 5Y 累计收益排序）· "
-                f"过滤 {passive_count} 家 ETF/指数基金"
+                f"共 {total_funds} 家基金持有 · "
+                f"头部 {len(top_full)} 家算完整 5Y 业绩（按持仓排序），"
+                f"其余 {lite_count} 家只列清单（点 fund_url 跳东财看详情）· "
+                f"过滤 {passive_count} 家 ETF/指数基金 · "
+                f"UZI_FUND_STATS_TOP=N 可调"
             ),
         },
-        "source": "akshare:stock_fund_stock_holder + fund_open_fund_info_em",
+        "source": "akshare:stock_fund_stock_holder + fund_open_fund_info_em(top N only)",
         "fallback": False,
     }
 

--- a/skills/deep-analysis/scripts/fetch_industry.py
+++ b/skills/deep-analysis/scripts/fetch_industry.py
@@ -170,8 +170,13 @@ def main(industry: str) -> dict:
     #   1. INDUSTRY_ESTIMATES 硬编码（手工策展的 7 个高频行业保留做 anchor）
     #   2. search_trusted 动态查权威域（236 个未覆盖行业的兜底）
     #   3. cninfo 行业 PE 加权 metrics（独立源，始终尝试）
+    # v2.10.1 · lite mode 跳过 dynamic 查询（节省 3-9 次 ddgs 请求）
+    import os
     est = _best_industry_match(industry)
-    dynamic = {} if est else _dynamic_industry_overview(industry)
+    if os.environ.get("UZI_LITE") == "1":
+        dynamic = {}
+    else:
+        dynamic = {} if est else _dynamic_industry_overview(industry)
 
     # Get cninfo aggregated metrics
     cninfo_metrics = _cninfo_industry_metrics(industry)

--- a/skills/deep-analysis/scripts/lib/analysis_profile.py
+++ b/skills/deep-analysis/scripts/lib/analysis_profile.py
@@ -1,0 +1,221 @@
+"""三档思考深度 · v2.10.2.
+
+用户选择 `lite / medium / deep`，决定所有下游子系统的行为：
+  - fetcher 集合（跑哪几维）
+  - 评委数量（10/51/51+辩论）
+  - 机构方法（1/17/18）
+  - ddgs / agent 深度分析（全 skip / 按需 / 跑满）
+  - fund_holders 策略（top 5/20/all）
+  - 自查 gate 严格度
+
+使用:
+  from lib.analysis_profile import get_profile, DEPTH_LITE, DEPTH_MEDIUM, DEPTH_DEEP
+
+  profile = get_profile()         # 从 UZI_DEPTH env 读，默认 medium
+  profile = get_profile("lite")   # 显式指定
+
+  if profile.should_run_fetcher("3_macro"):
+      ...
+
+CLI 集成（run.py）:
+  python run.py 600519 --depth lite
+  UZI_DEPTH=deep python run.py 600519
+
+兼容:
+  - UZI_LITE=1 向后兼容 → 等价于 UZI_DEPTH=lite
+  - /quick-scan 隐式 depth=lite
+  - /ic-memo / /initiate 隐式 depth=deep
+  - /analyze-stock 默认 depth=medium
+"""
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass, field
+from typing import Literal
+
+Depth = Literal["lite", "medium", "deep"]
+
+DEPTH_LITE: Depth = "lite"
+DEPTH_MEDIUM: Depth = "medium"
+DEPTH_DEEP: Depth = "deep"
+
+
+@dataclass(frozen=True)
+class AnalysisProfile:
+    depth: Depth
+    label_cn: str
+    estimated_minutes: str
+
+    # === Fetcher 层 ===
+    # 哪些 fetcher 跑 · 未列出的 skip
+    fetchers_enabled: frozenset[str]
+    # ddgs / web_search 预算上限（lib.web_search 读此值）
+    ddg_budget: int
+    # fetch_industry 是否跑 dynamic search_trusted (~3-9 次 ddgs)
+    industry_dynamic_lookup: bool
+
+    # === Panel 层 ===
+    # 参与投票的评委数量（按 investor_db 前 N 或流派采样）
+    investors_count: int
+    # 是否启用 Bull-Bear 结构化辩论（v2.10.2 deep 才有）
+    enable_bull_bear_debate: bool
+
+    # === 机构方法层 ===
+    # 跑哪几种机构方法
+    institutional_methods: frozenset[str]
+    # Segmental Revenue Build-Up（v2.10 新方法）
+    enable_segmental_model: bool
+    # Owner Earnings / Narrative Gap（v2.10.2 planned）
+    enable_owner_earnings: bool
+    enable_narrative_gap: bool
+
+    # === Fund holders 策略 ===
+    # 头部几家算完整 5Y 业绩
+    fund_stats_top_n: int
+    # 是否展开其余家的 lite 清单
+    fund_lite_list_enabled: bool
+
+    # === Agent 深度分析 ===
+    # 6 维定性（3_macro / 13_policy / 14_moat / 15_events / 17_sentiment / 18_trap）是否要求 agent 深度介入
+    require_qualitative_deep_dive: bool
+
+    # === Self-review gate ===
+    # warning 是否也 block HTML 生成
+    self_review_block_warnings: bool
+
+
+# ═══════════════════════════════════════════════════════════════
+# Profile 定义
+# ═══════════════════════════════════════════════════════════════
+
+_CORE_FETCHERS = frozenset({
+    "0_basic", "1_financials", "2_kline",
+    "10_valuation", "11_governance", "15_events", "16_lhb",
+})
+_ALL_FETCHERS = frozenset({
+    "0_basic", "1_financials", "2_kline", "3_macro", "4_peers", "5_chain",
+    "6_research", "7_industry", "8_materials", "9_futures", "10_valuation",
+    "11_governance", "12_capital_flow", "13_policy", "14_moat", "15_events",
+    "16_lhb", "17_sentiment", "18_trap", "19_contests",
+})
+
+_PROFILES: dict[str, AnalysisProfile] = {
+    DEPTH_LITE: AnalysisProfile(
+        depth=DEPTH_LITE,
+        label_cn="速判模式",
+        estimated_minutes="1-2 分钟",
+        fetchers_enabled=_CORE_FETCHERS,
+        ddg_budget=0,                     # 全 skip
+        industry_dynamic_lookup=False,
+        investors_count=10,
+        enable_bull_bear_debate=False,
+        institutional_methods=frozenset({"dcf"}),
+        enable_segmental_model=False,
+        enable_owner_earnings=False,
+        enable_narrative_gap=False,
+        fund_stats_top_n=5,
+        fund_lite_list_enabled=False,    # 不展开全量清单
+        require_qualitative_deep_dive=False,
+        self_review_block_warnings=False,
+    ),
+    DEPTH_MEDIUM: AnalysisProfile(
+        depth=DEPTH_MEDIUM,
+        label_cn="标准分析",
+        estimated_minutes="5-8 分钟",
+        fetchers_enabled=_ALL_FETCHERS,
+        ddg_budget=30,                    # 标准预算
+        industry_dynamic_lookup=True,
+        investors_count=51,
+        enable_bull_bear_debate=False,
+        institutional_methods=frozenset({
+            "dcf", "comps", "lbo", "three_statement", "merger",
+            "initiating", "earnings", "catalysts", "thesis", "morning", "screen", "sector",
+            "ic_memo", "porter_bcg", "dd", "unit_economics", "portfolio_rebalance",
+        }),
+        enable_segmental_model=False,
+        enable_owner_earnings=False,
+        enable_narrative_gap=False,
+        fund_stats_top_n=20,
+        fund_lite_list_enabled=True,
+        require_qualitative_deep_dive=True,
+        self_review_block_warnings=False,
+    ),
+    DEPTH_DEEP: AnalysisProfile(
+        depth=DEPTH_DEEP,
+        label_cn="深度研究",
+        estimated_minutes="15-20 分钟",
+        fetchers_enabled=_ALL_FETCHERS,
+        ddg_budget=60,                    # 允许跑满
+        industry_dynamic_lookup=True,
+        investors_count=51,
+        enable_bull_bear_debate=True,     # ← deep 独享
+        institutional_methods=frozenset({
+            "dcf", "comps", "lbo", "three_statement", "merger",
+            "initiating", "earnings", "catalysts", "thesis", "morning", "screen", "sector",
+            "ic_memo", "porter_bcg", "dd", "unit_economics", "portfolio_rebalance",
+            "segmental",  # v2.10 新方法
+        }),
+        enable_segmental_model=True,
+        enable_owner_earnings=True,       # v2.10.2 planned
+        enable_narrative_gap=True,         # v2.10.2 planned
+        fund_stats_top_n=100,              # deep 给前 100 家完整
+        fund_lite_list_enabled=True,
+        require_qualitative_deep_dive=True,
+        self_review_block_warnings=True,   # ← deep: warning 也 block
+    ),
+}
+
+
+def get_profile(depth: str | None = None) -> AnalysisProfile:
+    """取当前 profile.
+
+    参数:
+      depth: 显式指定 lite/medium/deep；None 时从 UZI_DEPTH env 读（默认 medium）
+
+    向后兼容:
+      UZI_LITE=1 → 等价 depth=lite
+      UZI_LITE=0 → 等价 depth=medium（不强制 deep）
+    """
+    if depth is None:
+        depth = os.environ.get("UZI_DEPTH")
+        # 兼容老的 UZI_LITE
+        if depth is None:
+            lite_env = os.environ.get("UZI_LITE", "auto").lower()
+            if lite_env in ("1", "true", "yes", "on"):
+                depth = DEPTH_LITE
+            else:
+                depth = DEPTH_MEDIUM
+    depth = (depth or DEPTH_MEDIUM).lower()
+    if depth not in _PROFILES:
+        raise ValueError(f"unknown depth {depth!r}; expected one of {list(_PROFILES.keys())}")
+    return _PROFILES[depth]
+
+
+def apply_profile_to_env(profile: AnalysisProfile) -> None:
+    """把 profile 同步到下游子系统读的环境变量."""
+    os.environ["UZI_DEPTH"] = profile.depth
+    os.environ["UZI_LITE"] = "1" if profile.depth == DEPTH_LITE else "0"
+    os.environ["UZI_DDG_BUDGET"] = str(profile.ddg_budget) if profile.ddg_budget > 0 else "0"
+    os.environ["UZI_FUND_STATS_TOP"] = str(profile.fund_stats_top_n)
+
+
+def format_banner(profile: AnalysisProfile) -> str:
+    """启动时打印的 banner."""
+    icons = {DEPTH_LITE: "⚡", DEPTH_MEDIUM: "📊", DEPTH_DEEP: "🔬"}
+    icon = icons.get(profile.depth, "·")
+    lines = [
+        f"{icon} {profile.label_cn} · depth={profile.depth} · 预计 {profile.estimated_minutes}",
+        f"  · fetchers: {len(profile.fetchers_enabled)}/{len(_ALL_FETCHERS)} 维",
+        f"  · 评委: {profile.investors_count} 位" + ("（含 Bull-Bear 辩论）" if profile.enable_bull_bear_debate else ""),
+        f"  · 机构方法: {len(profile.institutional_methods)} 种",
+        f"  · ddgs 预算: {'无限' if profile.ddg_budget == 0 and profile.depth != DEPTH_LITE else profile.ddg_budget}",
+        f"  · fund_holders: 头部 {profile.fund_stats_top_n} 家完整",
+    ]
+    return "\n".join(lines)
+
+
+if __name__ == "__main__":
+    for d in (DEPTH_LITE, DEPTH_MEDIUM, DEPTH_DEEP):
+        p = get_profile(d)
+        print(format_banner(p))
+        print()

--- a/skills/deep-analysis/scripts/lib/market_router.py
+++ b/skills/deep-analysis/scripts/lib/market_router.py
@@ -137,6 +137,13 @@ def parse_ticker(raw: str) -> TickerInfo:
         code = s.removesuffix(".HK").lstrip("0") or "0"
         return TickerInfo(raw=raw, code=code, full=f"{code.zfill(5)}.HK", market="H")
 
+    # v2.10.2 · 3-位数纯数字（如 "700"/"981"）A 股不存在，走 HK
+    # 原逻辑：_RE_A_NUMERIC 要求 6 位，_RE_HK 匹配 4-5 位 → "700" 3 位都不匹配
+    # 落到最后 A 股兜底 → 错判为 A 股 code=700
+    if s.isdigit() and 3 <= len(s) <= 5:
+        padded = s.zfill(5)
+        return TickerInfo(raw=raw, code=s.lstrip("0") or "0", full=f"{padded}.HK", market="H")
+
     if _RE_HK.match(s) and not _RE_US.match(s):
         return TickerInfo(raw=raw, code=s.lstrip("0") or "0", full=f"{s.zfill(5)}.HK", market="H")
 

--- a/skills/deep-analysis/scripts/lib/net_timeout_guard.py
+++ b/skills/deep-analysis/scripts/lib/net_timeout_guard.py
@@ -1,0 +1,57 @@
+"""全局网络超时护栏 · v2.10.2.
+
+**问题**: akshare 内部大量 `requests.get()` 不带 timeout，走代理/GFW 不通时
+会卡到 TCP 默认 120s。单次看着还好，20 个 fetcher 叠加就是卡死。
+
+**修法**: module import 时 monkey-patch `requests.Session.request` / 顶层
+`requests.get/post`，注入默认 timeout。用户已显式设 timeout 的调用不受影响。
+
+**使用**:
+    # 在 run_real_test.py / 任何入口的最早期 import:
+    from lib.net_timeout_guard import install_default_timeout
+    install_default_timeout()
+
+    # 或直接 import 这个 module 会自动装（侧效应）
+    import lib.net_timeout_guard  # noqa
+
+**环境变量**:
+    UZI_HTTP_TIMEOUT  · 默认 20（秒）· 单次 HTTP 最长耗时
+"""
+from __future__ import annotations
+
+import os
+
+
+_INSTALLED = False
+
+
+def install_default_timeout() -> None:
+    """Monkey-patch requests 库，给所有不带 timeout 的调用注入默认超时."""
+    global _INSTALLED
+    if _INSTALLED:
+        return
+
+    try:
+        import requests
+        from requests.sessions import Session
+    except ImportError:
+        return
+
+    default_timeout = int(os.environ.get("UZI_HTTP_TIMEOUT", "20"))
+
+    _original_request = Session.request
+
+    def _patched_request(self, method, url, **kwargs):
+        # 只在调用方没显式传 timeout 时注入
+        if "timeout" not in kwargs or kwargs.get("timeout") is None:
+            kwargs["timeout"] = default_timeout
+        return _original_request(self, method, url, **kwargs)
+
+    Session.request = _patched_request
+
+    # 顶层 requests.get/post/... 也走相同逻辑（它们底层都是 Session）
+    _INSTALLED = True
+
+
+# Module-import 时自动装（简化集成）
+install_default_timeout()

--- a/skills/deep-analysis/scripts/lib/network_preflight.py
+++ b/skills/deep-analysis/scripts/lib/network_preflight.py
@@ -1,0 +1,115 @@
+"""网络预检 · v2.10.2.
+
+在 stage1 开始前快速 ping 几个关键域名，如果代理/GFW 挂了，**立即**告诉
+用户，而不是让他等 10 分钟每个 fetcher 挨个超时。
+
+**检查目标**:
+  · push2.eastmoney.com      — akshare 行情主源
+  · duckduckgo.com            — ddgs web search
+  · api.github.com            — 通用 canary (理论上不会被墙但代理可能挂)
+
+**输出**: 3 个域名的可达性 + 总体建议
+
+**使用**:
+    from lib.network_preflight import run_preflight
+    result = run_preflight()
+    if result["critical_failures"] > 2:
+        print("⚠️ 代理似乎大面积不通，建议 --depth lite 或修代理")
+"""
+from __future__ import annotations
+
+import socket
+import time
+from dataclasses import dataclass
+
+
+@dataclass
+class DomainCheck:
+    domain: str
+    reachable: bool
+    latency_ms: int
+    error: str = ""
+    purpose: str = ""
+
+
+_TARGETS = [
+    ("push2.eastmoney.com", "A 股行情 (akshare 主源)"),
+    ("duckduckgo.com",       "ddgs 定性查询"),
+    ("www.cninfo.com.cn",    "cninfo 行业 PE + 公告"),
+    ("stock.xueqiu.com",     "雪球数据"),
+    ("api.github.com",       "通用网络健康度"),
+]
+
+
+def _probe(domain: str, port: int = 443, timeout: float = 3.0) -> DomainCheck:
+    """TCP connect probe（不做 HTTP，只测底层连通）."""
+    t0 = time.time()
+    try:
+        sock = socket.create_connection((domain, port), timeout=timeout)
+        sock.close()
+        return DomainCheck(
+            domain=domain,
+            reachable=True,
+            latency_ms=int((time.time() - t0) * 1000),
+        )
+    except socket.gaierror as e:
+        return DomainCheck(domain=domain, reachable=False, latency_ms=int((time.time() - t0) * 1000),
+                           error=f"DNS fail: {e}")
+    except socket.timeout:
+        return DomainCheck(domain=domain, reachable=False, latency_ms=int(timeout * 1000),
+                           error=f"timeout > {timeout}s")
+    except Exception as e:
+        return DomainCheck(domain=domain, reachable=False, latency_ms=int((time.time() - t0) * 1000),
+                           error=f"{type(e).__name__}: {str(e)[:80]}")
+
+
+def run_preflight(verbose: bool = True, timeout: float = 3.0) -> dict:
+    """跑一遍预检。返回诊断字典."""
+    results: list[DomainCheck] = []
+    for domain, purpose in _TARGETS:
+        r = _probe(domain, timeout=timeout)
+        r.purpose = purpose
+        results.append(r)
+
+    reachable = sum(1 for r in results if r.reachable)
+    failures = len(results) - reachable
+    avg_latency = sum(r.latency_ms for r in results if r.reachable) / max(reachable, 1)
+
+    # 决策
+    if failures == 0:
+        advisory = "✓ 网络畅通"
+        severity = "ok"
+    elif failures == 1:
+        advisory = "⚠ 单点不通，整体可跑（可能个别 fetcher 降级）"
+        severity = "warning"
+    elif failures == 2:
+        advisory = "⚠⚠ 多点不通，建议 --depth lite 节省时间"
+        severity = "degraded"
+    else:
+        advisory = "🔴 代理/网络严重不通，强烈建议先修网络或用 --depth lite"
+        severity = "critical"
+
+    if verbose:
+        print(f"\n🌐 网络预检 ({reachable}/{len(results)} 通 · 均延迟 {avg_latency:.0f}ms)")
+        for r in results:
+            mark = f"✓ {r.latency_ms:4d}ms" if r.reachable else f"✗ {r.error[:40]}"
+            print(f"  {mark}  {r.domain:28} · {r.purpose}")
+        print(f"\n  {advisory}\n")
+
+    return {
+        "reachable": reachable,
+        "failures": failures,
+        "critical_failures": failures,  # alias
+        "avg_latency_ms": int(avg_latency),
+        "advisory": advisory,
+        "severity": severity,
+        "results": [
+            {"domain": r.domain, "reachable": r.reachable, "latency_ms": r.latency_ms,
+             "error": r.error, "purpose": r.purpose}
+            for r in results
+        ],
+    }
+
+
+if __name__ == "__main__":
+    run_preflight(verbose=True)

--- a/skills/deep-analysis/scripts/lib/providers/__init__.py
+++ b/skills/deep-analysis/scripts/lib/providers/__init__.py
@@ -138,6 +138,10 @@ def _auto_register():
         from . import baostock_provider  # noqa
     except Exception:
         pass
+    try:
+        from . import direct_http_provider  # noqa
+    except Exception:
+        pass
 
 
 _auto_register()

--- a/skills/deep-analysis/scripts/lib/providers/__init__.py
+++ b/skills/deep-analysis/scripts/lib/providers/__init__.py
@@ -1,0 +1,143 @@
+"""Data Provider Framework · v2.10.3.
+
+统一接入多个数据源做 **自动 failover**。目的：
+
+  · 主源 akshare 挂了不至于整个 fetcher 返空
+  · 用户有 Tushare/FMP 等可选 key 时自动启用更稳定源
+  · 下游 fetcher 不关心具体从哪拉，只要拿到数据
+
+## 架构
+
+```
+fetcher (e.g. fetch_financials)
+    ↓
+get_provider_chain("financials", market="A")   ← 按偏好+可用性排序的 providers
+    ↓
+for p in chain:
+    try:
+        return p.fetch_financials(ti)
+    except ProviderError:
+        continue
+```
+
+## 内置 providers（v2.10.3）
+
+  · akshare    (主 · 0 key · 默认)
+  · efinance   (冗余 · 0 key · 需 pip install efinance)
+  · tushare    (opt-in · 需 TUSHARE_TOKEN)
+  · baostock   (低层 · 0 key · 已装)
+
+## 环境变量
+
+  TUSHARE_TOKEN     · Tushare Pro token
+  UZI_PROVIDERS_<DIM>  · 单维度覆盖偏好，如 UZI_PROVIDERS_FINANCIALS=tushare,akshare
+"""
+from __future__ import annotations
+
+import os
+from typing import Any, Protocol, runtime_checkable
+
+
+class ProviderError(Exception):
+    """统一错误类型，让 fetch chain 能优雅 failover."""
+
+
+@runtime_checkable
+class Provider(Protocol):
+    """所有 provider 必须实现的协议."""
+    name: str
+    requires_key: bool
+    markets: tuple[str, ...]  # ("A",) / ("A", "H") / ("U",)
+
+    def is_available(self) -> bool:
+        """能否用（环境变量/依赖/网络都检查）."""
+        ...
+
+
+# ═══════════════════════════════════════════════════════════════
+# Registry
+# ═══════════════════════════════════════════════════════════════
+
+_REGISTRY: dict[str, Provider] = {}
+
+
+def register(provider: Provider) -> None:
+    """Provider 类模块内自动调用注册."""
+    _REGISTRY[provider.name] = provider
+
+
+def get(name: str) -> Provider | None:
+    return _REGISTRY.get(name)
+
+
+def list_providers(market: str | None = None, available_only: bool = False) -> list[Provider]:
+    """列出 provider · 可按 market 过滤 · 可只返回当前可用的."""
+    out = list(_REGISTRY.values())
+    if market:
+        out = [p for p in out if market in p.markets]
+    if available_only:
+        out = [p for p in out if p.is_available()]
+    return out
+
+
+def get_provider_chain(dim: str, market: str = "A") -> list[Provider]:
+    """返回一个给定维度+市场的 provider 优先级链.
+
+    优先级 = UZI_PROVIDERS_<DIM> env （逗号分隔 id）> 内置默认顺序
+    默认顺序：akshare → efinance → tushare → baostock
+    """
+    default_order = ["akshare", "efinance", "tushare", "baostock"]
+    env_key = f"UZI_PROVIDERS_{dim.upper()}"
+    env_val = os.environ.get(env_key)
+    if env_val:
+        order = [x.strip() for x in env_val.split(",") if x.strip()]
+    else:
+        order = default_order
+
+    chain: list[Provider] = []
+    for name in order:
+        p = _REGISTRY.get(name)
+        if p and market in p.markets and p.is_available():
+            chain.append(p)
+    return chain
+
+
+def health_check() -> dict[str, dict]:
+    """返回每个 provider 的健康度 + 诊断信息."""
+    out = {}
+    for name, p in _REGISTRY.items():
+        try:
+            avail = p.is_available()
+            out[name] = {
+                "available": avail,
+                "markets": list(p.markets),
+                "requires_key": p.requires_key,
+                "status": "ok" if avail else "unavailable",
+            }
+        except Exception as e:
+            out[name] = {"available": False, "status": f"error: {type(e).__name__}"}
+    return out
+
+
+# Auto-register built-in providers on import
+def _auto_register():
+    """import 时自动装所有内置 providers（失败的静默跳过）."""
+    try:
+        from . import akshare_provider  # noqa
+    except Exception:
+        pass
+    try:
+        from . import efinance_provider  # noqa
+    except Exception:
+        pass
+    try:
+        from . import tushare_provider  # noqa
+    except Exception:
+        pass
+    try:
+        from . import baostock_provider  # noqa
+    except Exception:
+        pass
+
+
+_auto_register()

--- a/skills/deep-analysis/scripts/lib/providers/akshare_provider.py
+++ b/skills/deep-analysis/scripts/lib/providers/akshare_provider.py
@@ -1,0 +1,44 @@
+"""AkShare provider · 现有默认主源的正式封装."""
+from __future__ import annotations
+
+from . import Provider, register, ProviderError
+
+try:
+    import akshare as ak
+    _AK_OK = True
+except ImportError:
+    ak = None
+    _AK_OK = False
+
+
+class _AkshareProvider:
+    name = "akshare"
+    requires_key = False
+    markets = ("A", "H", "U")
+
+    def is_available(self) -> bool:
+        return _AK_OK
+
+    # === 不同维度的统一接口 ===
+    # fetch_basic / fetch_financials 等 wave1-2 fetcher 可直接调
+
+    def fetch_financials_a(self, code: str) -> dict:
+        if not _AK_OK:
+            raise ProviderError("akshare 未安装")
+        try:
+            df = ak.stock_financial_abstract(symbol=code)
+            return {"ok": True, "raw": df.to_dict("records") if df is not None else []}
+        except Exception as e:
+            raise ProviderError(f"akshare.stock_financial_abstract: {e}")
+
+    def fetch_kline_a(self, code: str, period: str = "daily", start: str = "20200101") -> list[dict]:
+        if not _AK_OK:
+            raise ProviderError("akshare 未安装")
+        try:
+            df = ak.stock_zh_a_hist(symbol=code, period=period, start_date=start, adjust="qfq")
+            return df.to_dict("records") if df is not None else []
+        except Exception as e:
+            raise ProviderError(f"akshare.stock_zh_a_hist: {e}")
+
+
+register(_AkshareProvider())

--- a/skills/deep-analysis/scripts/lib/providers/baostock_provider.py
+++ b/skills/deep-analysis/scripts/lib/providers/baostock_provider.py
@@ -1,0 +1,98 @@
+"""BaoStock provider · 官方开源 · 0 key · A 股为主.
+
+目前已在 data_sources._kline_a_share_chain 里作 fallback 用。本 provider
+把它正式化，让 financials / 指标 也能通过 chain 调到。
+
+BaoStock (http://baostock.com) 完全免费，需要 login()/logout()。
+"""
+from __future__ import annotations
+
+from . import Provider, register, ProviderError
+
+try:
+    import baostock as bs  # type: ignore
+    _BS_OK = True
+except ImportError:
+    bs = None
+    _BS_OK = False
+
+
+class _BaostockProvider:
+    name = "baostock"
+    requires_key = False
+    markets = ("A",)
+
+    _logged_in = False
+
+    def is_available(self) -> bool:
+        return _BS_OK
+
+    def _ensure_login(self) -> None:
+        if self._logged_in or not _BS_OK:
+            return
+        lg = bs.login()
+        if lg.error_code != "0":
+            raise ProviderError(f"baostock login: {lg.error_code} {lg.error_msg}")
+        self._logged_in = True
+
+    def _bs_code(self, code: str) -> str:
+        """600519 → sh.600519 / 000001 → sz.000001."""
+        code6 = code.split(".")[0].zfill(6)
+        prefix = "sh." if code6.startswith(("60", "68", "90", "50", "51", "52", "56", "58", "10", "11")) else "sz."
+        return prefix + code6
+
+    def fetch_financials_a(self, code: str, years: int = 5) -> dict:
+        """利润表关键字段 · query_profit_data."""
+        if not _BS_OK:
+            raise ProviderError("baostock 未安装")
+        try:
+            self._ensure_login()
+            from datetime import datetime
+            bs_code = self._bs_code(code)
+            current_year = datetime.now().year
+            results = []
+            for y in range(current_year - years, current_year + 1):
+                for q in range(1, 5):
+                    rs = bs.query_profit_data(code=bs_code, year=y, quarter=q)
+                    while rs.error_code == "0" and rs.next():
+                        results.append(rs.get_row_data())
+            return {"ok": True, "raw": results, "fields": ["code", "pubDate", "statDate",
+                                                            "roeAvg", "npMargin", "gpMargin",
+                                                            "netProfit", "epsTTM", "MBRevenue"]}
+        except Exception as e:
+            raise ProviderError(f"baostock.profit_data: {e}")
+
+    def fetch_kline_a(self, code: str, start: str = "2020-01-01") -> list[dict]:
+        """K 线 · query_history_k_data_plus."""
+        if not _BS_OK:
+            raise ProviderError("baostock 未安装")
+        try:
+            self._ensure_login()
+            bs_code = self._bs_code(code)
+            rs = bs.query_history_k_data_plus(
+                bs_code,
+                "date,open,high,low,close,volume,amount,turn,pctChg",
+                start_date=start,
+                frequency="d",
+                adjustflag="2",  # 前复权
+            )
+            rows = []
+            while rs.error_code == "0" and rs.next():
+                row = rs.get_row_data()
+                rows.append({
+                    "date": row[0],
+                    "open": float(row[1] or 0),
+                    "high": float(row[2] or 0),
+                    "low": float(row[3] or 0),
+                    "close": float(row[4] or 0),
+                    "volume": float(row[5] or 0),
+                    "amount": float(row[6] or 0),
+                    "turn": float(row[7] or 0),
+                    "pct_chg": float(row[8] or 0),
+                })
+            return rows
+        except Exception as e:
+            raise ProviderError(f"baostock.kline: {e}")
+
+
+register(_BaostockProvider())

--- a/skills/deep-analysis/scripts/lib/providers/direct_http_provider.py
+++ b/skills/deep-analysis/scripts/lib/providers/direct_http_provider.py
@@ -1,0 +1,244 @@
+"""Direct HTTP provider · v2.10.3 · 脱离 akshare/yfinance 包装，直连网站抓行情.
+
+**为什么**:
+  1. akshare 内部全是爬虫，上游网站改版经常挂
+  2. 直连腾讯/新浪/etnet 官方行情接口更稳，且国内友好
+  3. 对 GFW 代理挂场景，直连的 HTTPS 比 akshare 走的 push2 更可靠
+
+**覆盖**:
+  - 腾讯 qt (qt.gtimg.cn)：A/H/U 三市场实时快照
+  - 腾讯 ifzq (web.ifzq.gtimg.cn)：K 线历史
+  - 新浪 hq (hq.sinajs.cn)：A/H/U 实时
+  - etnet 港股页面：HTML 解析现价
+
+**0 key · 国内直连稳定**（这些站点国内浏览器可见即可）
+
+这是 Codex 提议 `fetch_web_quote.py` 的正式实现，做成 provider 框架的一员，
+不是独立脚本。
+"""
+from __future__ import annotations
+
+import re
+from . import register, ProviderError
+
+try:
+    import requests
+    _REQ_OK = True
+except ImportError:
+    requests = None
+    _REQ_OK = False
+
+
+_UA = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/122.0 Safari/537.36"
+
+
+class _DirectHttpProvider:
+    """直连站点行情源 · 包含腾讯 qt / 新浪 hq / etnet 三个子源."""
+
+    name = "direct_http"
+    requires_key = False
+    markets = ("A", "H", "U")
+
+    def is_available(self) -> bool:
+        return _REQ_OK
+
+    # ═══════════════════════════════════════════════════════════════
+    # 腾讯 qt.gtimg.cn · A/H/U 实时快照
+    # ═══════════════════════════════════════════════════════════════
+    def fetch_quote_tencent(self, code: str, market: str) -> dict:
+        """
+        腾讯 qt 实时行情，返回 {price, open, prev_close, high, low, volume, amount}.
+
+        code format: A 股 6 位 (600519) / HK 5 位 (00700) / US 字母 (AAPL)
+        market: "A" / "H" / "U"
+        """
+        if not _REQ_OK:
+            raise ProviderError("requests 未安装")
+
+        if market == "A":
+            # sh600519 / sz000001
+            prefix = "sh" if code.startswith(("6", "9", "5", "1")) else "sz"
+            qt_code = f"{prefix}{code}"
+        elif market == "H":
+            # hk00700
+            qt_code = f"hk{code.zfill(5)}"
+        elif market == "U":
+            # usAAPL.OQ / usAAPL.N（腾讯要求加交易所后缀，不知道默认试 .OQ）
+            qt_code = f"us{code.upper()}"
+        else:
+            raise ProviderError(f"unsupported market: {market!r}")
+
+        url = f"http://qt.gtimg.cn/q={qt_code}"
+        try:
+            r = requests.get(url, headers={"User-Agent": _UA}, timeout=8)
+            r.encoding = "gbk"
+            text = r.text.strip()
+        except Exception as e:
+            raise ProviderError(f"tencent qt: {type(e).__name__}: {e}")
+
+        # 格式: v_sh600519="1~贵州茅台~600519~1500.0~1520.0~..."
+        m = re.search(r'"([^"]+)"', text)
+        if not m:
+            raise ProviderError(f"tencent qt empty response: {text[:80]}")
+        parts = m.group(1).split("~")
+        if len(parts) < 33:
+            raise ProviderError(f"tencent qt short response: {len(parts)} fields")
+
+        # 字段顺序（A 股 market=51）: 状态 / 名称 / 代码 / 当前价 / 昨收 / 今开 / 成交量(手) / 外盘 / 内盘 / 买一 ...
+        # 港股/美股字段略有不同，但前 6 个位置基本一致
+        try:
+            return {
+                "name": parts[1],
+                "code": parts[2],
+                "price": float(parts[3] or 0),
+                "prev_close": float(parts[4] or 0),
+                "open": float(parts[5] or 0),
+                "volume": float(parts[6] or 0),
+                "high": float(parts[33] if len(parts) > 33 else 0) or None,
+                "low": float(parts[34] if len(parts) > 34 else 0) or None,
+                "amount": float(parts[37] if len(parts) > 37 else 0) or None,
+                "source": f"tencent_qt:{qt_code}",
+            }
+        except (ValueError, IndexError) as e:
+            raise ProviderError(f"tencent qt parse: {e}")
+
+    # ═══════════════════════════════════════════════════════════════
+    # 新浪 hq.sinajs.cn · A/H/U 实时快照
+    # ═══════════════════════════════════════════════════════════════
+    def fetch_quote_sina(self, code: str, market: str) -> dict:
+        if not _REQ_OK:
+            raise ProviderError("requests 未安装")
+
+        if market == "A":
+            prefix = "sh" if code.startswith(("6", "9", "5", "1")) else "sz"
+            sina_code = f"{prefix}{code}"
+        elif market == "H":
+            # 新浪港股 hk00700
+            sina_code = f"hk{code.zfill(5)}"
+        elif market == "U":
+            # 新浪美股 gb_ 前缀小写
+            sina_code = f"gb_{code.lower()}"
+        else:
+            raise ProviderError(f"unsupported market: {market!r}")
+
+        url = f"http://hq.sinajs.cn/list={sina_code}"
+        try:
+            r = requests.get(url, headers={
+                "User-Agent": _UA,
+                "Referer": "http://finance.sina.com.cn",
+            }, timeout=8)
+            r.encoding = "gbk"
+            text = r.text.strip()
+        except Exception as e:
+            raise ProviderError(f"sina hq: {type(e).__name__}: {e}")
+
+        # 格式: var hq_str_sh600519="贵州茅台,1520.00,1500.00,..."
+        m = re.search(r'"([^"]+)"', text)
+        if not m:
+            raise ProviderError(f"sina hq empty: {text[:80]}")
+        fields = m.group(1).split(",")
+        if len(fields) < 6:
+            raise ProviderError(f"sina hq too short")
+
+        try:
+            if market == "A":
+                # 0:名称 1:开盘 2:昨收 3:当前 4:最高 5:最低 6:买一 7:卖一 8:成交量 9:成交额
+                return {
+                    "name": fields[0],
+                    "code": code,
+                    "open": float(fields[1] or 0),
+                    "prev_close": float(fields[2] or 0),
+                    "price": float(fields[3] or 0),
+                    "high": float(fields[4] or 0),
+                    "low": float(fields[5] or 0),
+                    "volume": float(fields[8] or 0) if len(fields) > 8 else 0,
+                    "amount": float(fields[9] or 0) if len(fields) > 9 else 0,
+                    "source": f"sina_hq:{sina_code}",
+                }
+            elif market == "H":
+                # 0:英文名 1:中文名 2:开盘 3:昨收 4:最高 5:最低 6:当前 ...
+                return {
+                    "name": fields[1] if len(fields) > 1 else "",
+                    "code": code,
+                    "open": float(fields[2] or 0),
+                    "prev_close": float(fields[3] or 0),
+                    "high": float(fields[4] or 0),
+                    "low": float(fields[5] or 0),
+                    "price": float(fields[6] or 0),
+                    "source": f"sina_hq:{sina_code}",
+                }
+            else:  # U
+                # 美股字段: name / price / change_pct / change / open / high / low / prev_close ...
+                return {
+                    "name": fields[0],
+                    "code": code,
+                    "price": float(fields[1] or 0),
+                    "open": float(fields[5] or 0) if len(fields) > 5 else None,
+                    "high": float(fields[6] or 0) if len(fields) > 6 else None,
+                    "low": float(fields[7] or 0) if len(fields) > 7 else None,
+                    "prev_close": float(fields[26] or 0) if len(fields) > 26 else None,
+                    "source": f"sina_hq:{sina_code}",
+                }
+        except (ValueError, IndexError) as e:
+            raise ProviderError(f"sina hq parse: {e}")
+
+    # ═══════════════════════════════════════════════════════════════
+    # etnet.com.hk · 港股页面级 fallback
+    # ═══════════════════════════════════════════════════════════════
+    def fetch_quote_etnet(self, code: str) -> dict:
+        """etnet 港股页面解析。仅在腾讯/新浪都挂时用."""
+        if not _REQ_OK:
+            raise ProviderError("requests 未安装")
+
+        code5 = code.zfill(5).lstrip("0") or "0"  # etnet 不要前导 0
+        url = f"https://www.etnet.com.hk/www/tc/stocks/realtime/quote.php?code={code5}"
+        try:
+            r = requests.get(url, headers={"User-Agent": _UA}, timeout=10)
+        except Exception as e:
+            raise ProviderError(f"etnet: {type(e).__name__}: {e}")
+
+        html = r.text
+        # 现价抓取 (etnet 页面有 class 标记)
+        # 简单正则抓关键字段
+        def _find(pattern, default=None):
+            m = re.search(pattern, html)
+            return m.group(1) if m else default
+
+        price_str = _find(r'realTimeQuote[^>]*>([\d.]+)', None) or \
+                    _find(r'"lastPrice"[^>]*>([\d.]+)', None)
+        if not price_str:
+            raise ProviderError("etnet: price element not found")
+
+        return {
+            "code": code,
+            "price": float(price_str),
+            "source": f"etnet:{code5}",
+            "_note": "页面级 fallback，字段不全",
+        }
+
+    # ═══════════════════════════════════════════════════════════════
+    # 统一入口 · chain 式兜底
+    # ═══════════════════════════════════════════════════════════════
+    def fetch_quote(self, code: str, market: str) -> dict:
+        """腾讯 → 新浪 → etnet（港股）三级兜底."""
+        errors = []
+        # 1. 腾讯
+        try:
+            return self.fetch_quote_tencent(code, market)
+        except ProviderError as e:
+            errors.append(str(e))
+        # 2. 新浪
+        try:
+            return self.fetch_quote_sina(code, market)
+        except ProviderError as e:
+            errors.append(str(e))
+        # 3. etnet（仅港股）
+        if market == "H":
+            try:
+                return self.fetch_quote_etnet(code)
+            except ProviderError as e:
+                errors.append(str(e))
+        raise ProviderError(f"direct_http all failed: {' | '.join(errors)}")
+
+
+register(_DirectHttpProvider())

--- a/skills/deep-analysis/scripts/lib/providers/efinance_provider.py
+++ b/skills/deep-analysis/scripts/lib/providers/efinance_provider.py
@@ -1,0 +1,83 @@
+"""Efinance provider · 0 key · akshare 的并行冗余.
+
+Efinance (https://github.com/Micro-sheep/efinance) 内部从东财、同花顺、新浪
+等多源爬虫聚合，国内直连稳定。提供 A/港/美 股 + ETF + 基金 + 可转债 全覆盖。
+
+安装：pip install efinance
+零 API key 要求。
+"""
+from __future__ import annotations
+
+from . import Provider, register, ProviderError
+
+try:
+    import efinance as ef  # type: ignore
+    _EF_OK = True
+except ImportError:
+    ef = None
+    _EF_OK = False
+
+
+class _EfinanceProvider:
+    name = "efinance"
+    requires_key = False
+    markets = ("A", "H", "U")
+
+    def is_available(self) -> bool:
+        return _EF_OK
+
+    def fetch_basic_a(self, code: str) -> dict:
+        """A 股基本信息 + 最新行情（走东财爬虫）."""
+        if not _EF_OK:
+            raise ProviderError("efinance 未安装")
+        try:
+            # efinance.stock.get_base_info 返回 DataFrame（code/name/行业/市盈率等）
+            df = ef.stock.get_base_info(code)
+            if df is None or (hasattr(df, 'empty') and df.empty):
+                raise ProviderError("empty response")
+            if hasattr(df, 'to_dict'):
+                rec = df.to_dict("records")[0] if not df.empty else {}
+            else:
+                rec = dict(df)
+            return {"ok": True, "raw": rec}
+        except Exception as e:
+            raise ProviderError(f"efinance.get_base_info: {e}")
+
+    def fetch_kline(self, code: str, market: str = "A", days: int = 500) -> list[dict]:
+        """K 线 · efinance 支持 A/港/美/ETF/基金 一致接口."""
+        if not _EF_OK:
+            raise ProviderError("efinance 未安装")
+        try:
+            df = ef.stock.get_quote_history(code)
+            if df is None or df.empty:
+                raise ProviderError("empty kline")
+            return df.tail(days).to_dict("records")
+        except Exception as e:
+            raise ProviderError(f"efinance.get_quote_history: {e}")
+
+    def fetch_realtime_quote(self, code: str) -> dict:
+        """实时行情快照."""
+        if not _EF_OK:
+            raise ProviderError("efinance 未安装")
+        try:
+            df = ef.stock.get_realtime_quotes(fs=code) if hasattr(ef.stock, "get_realtime_quotes") else None
+            if df is None or df.empty:
+                raise ProviderError("empty realtime")
+            return df.to_dict("records")[0]
+        except Exception as e:
+            raise ProviderError(f"efinance realtime: {e}")
+
+    def fetch_fund_holders(self, code: str) -> list[dict]:
+        """基金持仓（哪些基金持有本股）· 作为 akshare 的冗余."""
+        if not _EF_OK:
+            raise ProviderError("efinance 未安装")
+        try:
+            # efinance 有 fund.get_inverst_position，是 基金 → 持仓
+            # 反查 "持有本股的基金" 需要反向用东财 API（efinance 不直接提供）
+            # 这里只作 akshare stock_fund_stock_holder 失败时的 fallback 点位
+            raise ProviderError("efinance 不直接提供股票→基金反查，跳过")
+        except Exception as e:
+            raise ProviderError(str(e))
+
+
+register(_EfinanceProvider())

--- a/skills/deep-analysis/scripts/lib/providers/tushare_provider.py
+++ b/skills/deep-analysis/scripts/lib/providers/tushare_provider.py
@@ -1,0 +1,119 @@
+"""Tushare Pro provider · 需 TUSHARE_TOKEN · 官方级冗余.
+
+Tushare Pro (https://tushare.pro) 是 A 股最专业的官方 API 之一：
+  · 财报深度历史 (5-10 年)
+  · 机构级龙虎榜 / 北向 / 期货逐笔
+  · ISO 数据清洗流程，字段稳定性 >> akshare 爬虫
+
+免费额度：新账号 120 分，常用接口 2000 分（贡献数据 / 充值）。
+
+配置：
+  1. 访问 https://tushare.pro 注册
+  2. 个人中心 → 接口 TOKEN
+  3. export TUSHARE_TOKEN=your_token
+"""
+from __future__ import annotations
+
+import os
+from . import Provider, register, ProviderError
+
+try:
+    import tushare as ts  # type: ignore
+    _TS_OK = True
+except ImportError:
+    ts = None
+    _TS_OK = False
+
+
+class _TushareProvider:
+    name = "tushare"
+    requires_key = True
+    markets = ("A",)  # Tushare 主要覆盖 A 股
+
+    _pro = None
+
+    def is_available(self) -> bool:
+        if not _TS_OK:
+            return False
+        token = os.environ.get("TUSHARE_TOKEN", "").strip()
+        return bool(token)
+
+    def _get_pro(self):
+        """懒初始化 tushare.pro_api."""
+        if self._pro is not None:
+            return self._pro
+        if not self.is_available():
+            raise ProviderError("Tushare 未启用（pip install tushare + TUSHARE_TOKEN）")
+        token = os.environ["TUSHARE_TOKEN"]
+        ts.set_token(token)
+        self._pro = ts.pro_api()
+        return self._pro
+
+    def _ts_code(self, code: str) -> str:
+        """A 股 6 位码 → Tushare 格式 (600519 → 600519.SH)."""
+        code6 = code.split(".")[0].zfill(6)
+        if code6.startswith(("60", "68", "90", "50", "51", "52", "56", "58", "10", "11")):
+            return f"{code6}.SH"
+        if code6.startswith(("83", "87", "88", "92")):
+            return f"{code6}.BJ"
+        return f"{code6}.SZ"
+
+    def fetch_basic_a(self, code: str) -> dict:
+        """stock_basic · 基础信息."""
+        try:
+            pro = self._get_pro()
+            df = pro.stock_basic(ts_code=self._ts_code(code), fields="ts_code,symbol,name,industry,market,list_date")
+            if df is None or df.empty:
+                raise ProviderError("tushare stock_basic empty")
+            return {"ok": True, "raw": df.to_dict("records")[0]}
+        except ProviderError:
+            raise
+        except Exception as e:
+            raise ProviderError(f"tushare.stock_basic: {e}")
+
+    def fetch_financials_a(self, code: str, years: int = 5) -> dict:
+        """利润表 + 资产负债表 + 现金流表 · 3 表 N 年深度历史."""
+        try:
+            pro = self._get_pro()
+            ts_code = self._ts_code(code)
+            income = pro.income(ts_code=ts_code, limit=years * 4)
+            balance = pro.balancesheet(ts_code=ts_code, limit=years * 4)
+            cashflow = pro.cashflow(ts_code=ts_code, limit=years * 4)
+            return {
+                "ok": True,
+                "income": income.to_dict("records") if income is not None else [],
+                "balance": balance.to_dict("records") if balance is not None else [],
+                "cashflow": cashflow.to_dict("records") if cashflow is not None else [],
+            }
+        except Exception as e:
+            raise ProviderError(f"tushare.financials: {e}")
+
+    def fetch_top10_holders(self, code: str) -> list[dict]:
+        """前十大流通股东."""
+        try:
+            pro = self._get_pro()
+            df = pro.top10_floatholders(ts_code=self._ts_code(code))
+            return df.to_dict("records") if df is not None else []
+        except Exception as e:
+            raise ProviderError(f"tushare.top10_floatholders: {e}")
+
+    def fetch_top_list(self, code: str, start: str, end: str) -> list[dict]:
+        """龙虎榜 · 席位详情（比 akshare 覆盖更深）."""
+        try:
+            pro = self._get_pro()
+            df = pro.top_list(ts_code=self._ts_code(code), start_date=start, end_date=end)
+            return df.to_dict("records") if df is not None else []
+        except Exception as e:
+            raise ProviderError(f"tushare.top_list: {e}")
+
+    def fetch_hsgt_flow(self, date: str = "") -> list[dict]:
+        """北向资金流向（机构级）."""
+        try:
+            pro = self._get_pro()
+            df = pro.moneyflow_hsgt(trade_date=date) if date else pro.moneyflow_hsgt()
+            return df.to_dict("records") if df is not None else []
+        except Exception as e:
+            raise ProviderError(f"tushare.hsgt: {e}")
+
+
+register(_TushareProvider())

--- a/skills/deep-analysis/scripts/lib/web_search.py
+++ b/skills/deep-analysis/scripts/lib/web_search.py
@@ -24,6 +24,45 @@ _SEARCH_TTL = 12 * 60 * 60  # 12h — news can update but we don't need bleeding
 
 
 # ═══════════════════════════════════════════════════════════════
+# v2.10.1 · 全局 ddgs 预算（防止首次跑爆炸 + Codex token 消耗过大）
+# ═══════════════════════════════════════════════════════════════
+# UZI_LITE=1 时 search() 进入严格预算模式：全生命周期最多 N 次真实搜索
+# （命中 cache 的不计）。超出后直接返空，agent 会看到空结果知道走备选。
+import threading as _threading
+_BUDGET_LOCK = _threading.Lock()
+_BUDGET_STATE = {"used": 0, "skipped": 0}
+
+
+def _budget_allows() -> bool:
+    import os
+    cap_raw = os.environ.get("UZI_DDG_BUDGET")
+    if not cap_raw:
+        return True  # 未设预算 = 无限
+    try:
+        cap = int(cap_raw)
+    except ValueError:
+        return True
+    with _BUDGET_LOCK:
+        return _BUDGET_STATE["used"] < cap
+
+
+def _budget_mark_used(n: int = 1) -> None:
+    with _BUDGET_LOCK:
+        _BUDGET_STATE["used"] += n
+
+
+def _budget_mark_skipped(n: int = 1) -> None:
+    with _BUDGET_LOCK:
+        _BUDGET_STATE["skipped"] += n
+
+
+def get_budget_state() -> dict:
+    """让 fetcher 和 self_review 能查用量."""
+    with _BUDGET_LOCK:
+        return dict(_BUDGET_STATE)
+
+
+# ═══════════════════════════════════════════════════════════════
 # v2.7.3 · Trusted authority domains per dimension
 # ═══════════════════════════════════════════════════════════════
 # 把 Codex 建议的权威媒体 + 官方宏观源映射到定性维度。fetcher 可以调
@@ -114,16 +153,24 @@ def search(query: str, max_results: int = 10, cache_key_prefix: str = "ws") -> l
 
     Includes a quality filter to remove dictionary/Wikipedia garbage results
     that match Chinese character definitions instead of stock analysis.
+
+    v2.10.1 · 命中 cache 的不占预算；未命中 cache 时检查 UZI_DDG_BUDGET 预算。
     """
     key = f"{cache_key_prefix}__{query[:100]}__n{max_results}"
-    raw = cached(
-        "_global",
-        key,
-        lambda: _ddg_search(query, max_results=max_results),
-        ttl=_SEARCH_TTL,
-    )
-    # Quality filter: remove dictionary/wikipedia garbage
-    return [r for r in raw if not _is_garbage_result(r)]
+
+    # 先检查 cache 是否命中 —— 命中不占预算
+    from lib.cache import cached, TTL_HOURLY  # re-import for scope
+    # 自定义：先看 cache 有没有，没 cache 时查预算
+    def _fetcher():
+        if not _budget_allows():
+            _budget_mark_skipped()
+            return [{"_budget_exceeded": True,
+                     "body": "全局 ddgs 预算已用尽（UZI_DDG_BUDGET），agent 请用 cached / hardcoded 数据"}]
+        _budget_mark_used()
+        return _ddg_search(query, max_results=max_results)
+
+    raw = cached("_global", key, _fetcher, ttl=_SEARCH_TTL)
+    return [r for r in raw if not _is_garbage_result(r) and not r.get("_budget_exceeded")]
 
 
 def search_trusted(

--- a/skills/deep-analysis/scripts/lib/web_search.py
+++ b/skills/deep-analysis/scripts/lib/web_search.py
@@ -110,16 +110,25 @@ def trusted_domains_for(dim_key: str) -> tuple[str, ...]:
 
 
 def _ddg_search(query: str, max_results: int = 10, region: str = "cn-zh") -> list[dict]:
+    """v2.10.2 · 加硬超时保护（代理/GFW 挂时卡 60s+ 的核心原因）."""
     if not _DDGS_OK:
         return []
-    try:
+    # 用独立线程 + 硬超时把 DDGS 内部无 timeout 的 requests 兜住
+    # UZI_DDG_TIMEOUT 可调（默认 10 秒）
+    import os, concurrent.futures as _cf
+    timeout_sec = int(os.environ.get("UZI_DDG_TIMEOUT", "10"))
+
+    def _inner():
         with DDGS() as d:
-            results = list(d.text(
-                query,
-                region=region,
-                safesearch="off",
-                max_results=max_results,
+            return list(d.text(
+                query, region=region, safesearch="off", max_results=max_results,
             ))
+    try:
+        with _cf.ThreadPoolExecutor(max_workers=1) as pool:
+            try:
+                results = pool.submit(_inner).result(timeout=timeout_sec)
+            except _cf.TimeoutError:
+                return [{"error": f"ddgs: timeout > {timeout_sec}s（代理/网络不通？）"}]
         # Normalize fields
         return [
             {

--- a/skills/deep-analysis/scripts/prewarm_cache.py
+++ b/skills/deep-analysis/scripts/prewarm_cache.py
@@ -1,0 +1,243 @@
+#!/usr/bin/env python3
+"""v2.10.2 · 预热 cache 生成脚本 · 全公开数据，0 敏感信息.
+
+目的:
+  Codex + 首次安装机器慢的根因是 `.cache/_global/api_cache/` 为空导致
+  所有 ddgs / 行业分类 / 基金 NAV 都得真实跑一遍。本脚本一次性跑完
+  这些"所有用户都会用到的公开数据"，输出 prewarm/ 目录可打包分发。
+
+用法:
+    # 本地跑一次生成预热包
+    python prewarm_cache.py
+
+    # 输出: prewarm/api_cache/*.json
+    # 打包: tar czf prewarm-v2.10.tar.gz prewarm/
+
+用户侧使用:
+    curl -L https://github.com/wbh604/UZI-Skill/releases/download/v2.10.2/prewarm-v2.10.tar.gz | tar xz
+    mv prewarm/api_cache/* skills/deep-analysis/scripts/.cache/_global/api_cache/
+
+安全保证（绝不打包）:
+  - .env / MX_APIKEY / 任何 API 凭证
+  - 用户雪球 cookie (~/.uzi-skill/playwright-xueqiu/)
+  - 用户跑过的 .cache/<ticker>/  (可能暴露投资偏好)
+  - 任何含用户本机绝对路径的内容
+"""
+from __future__ import annotations
+
+import json
+import os
+import sys
+import warnings
+from datetime import datetime, timedelta
+from pathlib import Path
+
+warnings.filterwarnings("ignore")
+SCRIPT_DIR = Path(__file__).resolve().parent
+sys.path.insert(0, str(SCRIPT_DIR))
+
+OUT_DIR = SCRIPT_DIR / "prewarm" / "api_cache"
+
+
+def _ensure_out() -> None:
+    OUT_DIR.mkdir(parents=True, exist_ok=True)
+    # 安全检查：确保输出目录不在 user home 下（防止意外把用户数据带走）
+    out_str = str(OUT_DIR.resolve())
+    assert "UZI-Skill" in out_str, f"安全检查失败: 输出路径可疑 {out_str}"
+
+
+def _save(key: str, data) -> None:
+    """保存一条 cache entry，格式匹配 lib.cache.cached 的写入格式."""
+    p = OUT_DIR / f"{key}.json"
+    payload = {"_cached_at": datetime.now().isoformat(timespec="seconds"), "data": data}
+    p.write_text(json.dumps(payload, ensure_ascii=False, default=str), encoding="utf-8")
+
+
+def warm_industry_taxonomy() -> int:
+    """证监会行业分类 · 所有 A 股通用 · 日级更新."""
+    print("\n[1/5] 证监会行业分类 · 近 7 日")
+    import akshare as ak
+    today = datetime.now()
+    n = 0
+    for i in range(1, 8):
+        d = (today - timedelta(days=i)).strftime("%Y%m%d")
+        try:
+            df = ak.stock_industry_pe_ratio_cninfo(symbol="证监会行业分类", date=d)
+            if df is None or df.empty:
+                continue
+            key = f"industry_pe__{d}"
+            _save(key, df.to_dict("records"))
+            n += 1
+            print(f"    ✓ {d}: {len(df)} 行")
+        except Exception as e:
+            print(f"    ✗ {d}: {type(e).__name__}: {str(e)[:60]}")
+    return n
+
+
+def warm_stock_name_table() -> int:
+    """A 股全量 code ↔ name 映射 · 中文名解析用."""
+    print("\n[2/5] A 股全量 code ↔ name 表")
+    import akshare as ak
+    try:
+        df = ak.stock_info_a_code_name()
+        if df is not None and not df.empty:
+            _save("stock_info_a_code_name", df.to_dict("records"))
+            print(f"    ✓ 共 {len(df)} 只 A 股")
+            return 1
+    except Exception as e:
+        print(f"    ✗ {type(e).__name__}: {str(e)[:80]}")
+    return 0
+
+
+def warm_qualitative_searches() -> int:
+    """v2.10.2 · 高频 ddgs 定性查询，让 fetch_macro/policy/moat 首跑命中 cache.
+
+    只预热**跨股通用**的查询（宏观/行业）· 不预热个股特定查询（那会带用户色彩）。
+    """
+    print("\n[3/5] 高频 ddgs 定性查询（权威域）")
+    from lib.web_search import search_trusted
+
+    year = datetime.now().year
+    # 所有用户分析任何 A 股都会触发的"跨股通用"查询
+    UNIVERSAL_QUERIES = [
+        # 3_macro · 宏观
+        ("3_macro", f"{year} 中国 利率 货币政策 降息 最新"),
+        ("3_macro", f"{year} 美联储 利率周期 最新"),
+        ("3_macro", f"{year} 人民币 汇率 走势"),
+        # 13_policy · 常见行业政策
+        ("13_policy", f"{year} 白酒 国家政策 扶持 利好"),
+        ("13_policy", f"{year} 半导体 国产替代 政策"),
+        ("13_policy", f"{year} 新能源 政策 利好"),
+        ("13_policy", f"{year} 医药 集采 政策"),
+        ("13_policy", f"{year} 有色金属 国家政策"),
+        ("13_policy", f"{year} 工业金属 政策 扶持"),
+        # 14_moat · 常见行业护城河关键词
+        ("14_moat", f"白酒 上市公司 品牌壁垒 竞争优势"),
+        ("14_moat", f"半导体 上市公司 专利 核心技术"),
+        ("14_moat", f"新能源 上市公司 市场份额 龙头"),
+    ]
+    n = 0
+    for dim_key, q in UNIVERSAL_QUERIES:
+        try:
+            # search_trusted 内部用 lib.cache.cached，写到 _global/api_cache
+            results = search_trusted(q, dim_key=dim_key, max_results=4)
+            if results and "error" not in (results[0] if results else {}):
+                n += 1
+                print(f"    ✓ [{dim_key}] {q[:50]}... ({len(results)} 条)")
+        except Exception as e:
+            print(f"    ✗ {q[:40]}: {type(e).__name__}")
+    return n
+
+
+def warm_common_fund_nav() -> int:
+    """常见公募基金经理的 5Y NAV · 多股共享（一个基金可能被多只股票的分析引用）."""
+    print("\n[4/5] Top 20 公募基金 5Y NAV")
+    import akshare as ak
+    # 代表性公募基金（张坤/谢治宇/朱少醒等 Top 大佬管理的几只）
+    COMMON_FUNDS = [
+        "005827",  # 易方达蓝筹精选（张坤）
+        "163402",  # 兴全趋势（谢治宇）
+        "519035",  # 富国天惠（朱少醒）
+        "001856",  # 兴全合润
+        "519732",  # 交银精选回报
+        "110011",  # 易方达优质精选（萧楠）
+        "001875",  # 前海开源中航军工
+        "161725",  # 招商中证白酒指数
+        "005669",  # 广发高端制造
+        "004674",  # 鹏华优势
+    ]
+    n = 0
+    for code in COMMON_FUNDS:
+        try:
+            df = ak.fund_open_fund_info_em(symbol=code, indicator="累计净值走势")
+            if df is not None and not df.empty:
+                # 保留近 5 年
+                cutoff = f"{datetime.now().year - 5}-01-01"
+                date_col = "净值日期" if "净值日期" in df.columns else df.columns[0]
+                df5 = df[df[date_col].astype(str) >= cutoff] if date_col else df
+                key = f"fund_nav__{code}"
+                _save(key, df5.tail(1500).to_dict("records"))
+                n += 1
+                print(f"    ✓ {code}: {len(df5)} 个 NAV 点")
+        except Exception as e:
+            print(f"    ✗ {code}: {type(e).__name__}: {str(e)[:60]}")
+    return n
+
+
+def warm_futures_main() -> int:
+    """主要期货品种 12 个月历史 · 8_materials / 9_futures 所有金属/能源股通用."""
+    print("\n[5/5] 主连期货价格（12 个月）")
+    import akshare as ak
+    SYMBOLS = ["AL0", "CU0", "ZN0", "NI0", "AU0", "AG0", "SN0", "PB0",
+               "RB0", "I0", "J0", "JM0", "ZC0", "SC0", "MA0", "PP0", "V0"]
+    n = 0
+    for sym in SYMBOLS:
+        try:
+            df = ak.futures_main_sina(symbol=sym)
+            if df is not None and not df.empty:
+                key = f"futures_main__{sym}"
+                _save(key, df.tail(260).to_dict("records"))
+                n += 1
+                print(f"    ✓ {sym}: {len(df)} 行")
+        except Exception as e:
+            print(f"    ✗ {sym}: {type(e).__name__}")
+    return n
+
+
+def sanity_check_output() -> None:
+    """生成后扫一遍输出，确保没有敏感信息混入."""
+    print("\n[SAFETY] 输出内容敏感性扫描")
+    suspicious_patterns = [
+        # 常见 API key 格式
+        ("sk-", "OpenAI key 格式"),
+        ("mkt_", "MX API key 格式"),
+        ("pk_", "私钥格式"),
+        # 个人路径
+        ("/Users/", "macOS 个人路径"),
+        ("/home/", "Linux 个人路径"),
+        ("C:\\Users\\", "Windows 个人路径"),
+        # 邮箱 / 电话
+        ("@qq.com", "QQ 邮箱"),
+        ("@163.com", "163 邮箱"),
+        ("@gmail.com", "Gmail"),
+    ]
+    issues = []
+    for f in OUT_DIR.glob("*.json"):
+        content = f.read_text(encoding="utf-8", errors="replace")
+        for pat, label in suspicious_patterns:
+            if pat in content:
+                issues.append(f"  {f.name}: 含 {label} ({pat!r})")
+    if issues:
+        print("  ⚠️ 发现潜在敏感内容：")
+        for i in issues: print(i)
+        print("  请人工审查后再打包分发")
+    else:
+        print("  ✓ 扫描通过，未发现敏感信息")
+
+
+def main() -> int:
+    _ensure_out()
+    print(f"输出目录: {OUT_DIR}")
+    print(f"开始预热 @ {datetime.now().isoformat(timespec='seconds')}\n")
+
+    total = 0
+    total += warm_industry_taxonomy()
+    total += warm_stock_name_table()
+    total += warm_qualitative_searches()
+    total += warm_common_fund_nav()
+    total += warm_futures_main()
+
+    sanity_check_output()
+
+    # 大小统计
+    total_bytes = sum(f.stat().st_size for f in OUT_DIR.glob("*.json"))
+    file_count = len(list(OUT_DIR.glob("*.json")))
+    print(f"\n=== 完成 ===")
+    print(f"生成 {file_count} 个 cache 文件 · 共 {total_bytes/1024:.1f} KB")
+    print(f"→ 打包: tar czf prewarm-$(cat .version-bump.json | python3 -c 'import json,sys;print(json.load(sys.stdin)[\"version\"])').tar.gz prewarm/")
+    print(f"→ 用户下载后解压到: .cache/_global/api_cache/")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/skills/deep-analysis/scripts/run_real_test.py
+++ b/skills/deep-analysis/scripts/run_real_test.py
@@ -265,10 +265,14 @@ def collect_raw_data(ticker: str, max_workers: int = 6, resume: bool = True) -> 
     def _fund_holders():
         try:
             import fetch_fund_holders
-            # BUG#R2 fix: v2.4 已把 fetcher limit 改为 None（不截断），但 wave3 调用
-            # 还是写死 limit=6 → 报告里只显示 6 个基金。这次同步移除调用层的截断。
-            # 茅台 649 家、浙江东方 80 家全收录；render_fund_managers 已支持紧凑行展开。
-            fh = fetch_fund_holders.main(ticker, limit=None)
+            # v2.10.1 · 性能优化：默认 limit=20（茅台级大票原先 649 家逐家 akshare
+            # 查询需要 5-10 分钟，对 codex + 首次安装机器是主要耗时瓶颈）。
+            # 大多数分析场景前 20 大基金持仓已能反映机构偏好；需要全量可设
+            # UZI_FUND_LIMIT=all 或 UZI_FUND_LIMIT=<N> 覆盖。
+            import os
+            fl = os.environ.get("UZI_FUND_LIMIT", "20")
+            limit = None if fl in ("all", "none", "None", "0") else int(fl)
+            fh = fetch_fund_holders.main(ticker, limit=limit)
             return ("fund_managers", (fh.get("data") or {}).get("fund_managers", []), None)
         except Exception as e:
             return ("fund_managers", [], str(e))
@@ -1409,6 +1413,40 @@ def generate_synthesis(raw: dict, dims_scored: dict, panel: dict, agent_analysis
     }
 
 
+def _detect_lite_mode() -> tuple[bool, str]:
+    """v2.10.1 · 三种方式决定是否进 lite mode:
+
+    1. UZI_LITE=1 env（显式）
+    2. UZI_LITE=auto 或未设置 → 自动检测首次安装（.cache/_global 为空）
+    3. UZI_LITE=0 → 强制关闭
+
+    Lite mode 影响:
+      - fetch_macro / fetch_policy / fetch_moat 跳过 ddgs（返空让 agent 知道）
+      - fetch_industry 跳过 _dynamic_industry_overview（省 3-9 次 ddgs）
+      - wave3 fund_managers 不改（已有 UZI_FUND_LIMIT 控制）
+      - HTML 报告正常生成，但会显示"⚡ LITE MODE 跑完后可去 LITE=0 补数据"
+
+    返回 (is_lite: bool, reason: str)
+    """
+    import os
+    from pathlib import Path
+    val = os.environ.get("UZI_LITE", "auto").lower()
+    if val in ("1", "true", "yes", "on"):
+        return True, "UZI_LITE=1 显式启用"
+    if val in ("0", "false", "no", "off"):
+        return False, "UZI_LITE=0 显式关闭"
+    # auto 模式：检测 _global api_cache 是否为空（首次安装判定）
+    global_cache = Path(".cache/_global/api_cache")
+    if not global_cache.exists():
+        return True, "首次安装（.cache/_global 不存在）自动 lite"
+    try:
+        if len(list(global_cache.iterdir())) < 5:
+            return True, "cache 非常冷（_global/api_cache 条目 < 5）自动 lite"
+    except Exception:
+        pass
+    return False, "cache 已预热，full mode"
+
+
 def stage1(ticker: str) -> dict:
     """Stage 1: 数据采集 + 建模 + 规则引擎骨架分。
 
@@ -1416,6 +1454,18 @@ def stage1(ticker: str) -> dict:
     Claude 应该在 stage1 之后介入，用 sub-agent 逐组分析 51 评委，
     覆盖 panel.json 中的 headline/reasoning/score，然后调 stage2 生成报告。
     """
+    # v2.10.1 · 性能模式自动探测（解决 codex + 首次安装机器慢的问题）
+    import os
+    is_lite, lite_reason = _detect_lite_mode()
+    if is_lite:
+        os.environ["UZI_LITE"] = "1"  # 下游 fetcher 能读
+        os.environ.setdefault("UZI_DDG_BUDGET", "15")  # 全局 ddgs 预算上限
+        print(f"\n⚡ LITE MODE: {lite_reason}")
+        print(f"   · 跳过 fetch_macro/policy/moat 的 ddgs 查询（返回空让 agent 自己补）")
+        print(f"   · fetch_industry 跳过动态景气度查询（省 3-9 次 ddgs）")
+        print(f"   · wave3 fund_holders 默认 top 20（UZI_FUND_LIMIT=all 可覆盖）")
+        print(f"   · 全局 ddgs 预算 15 次/ticker（超出自动 skip）")
+        print(f"   · 完整跑请 UZI_LITE=0 && python run.py <ticker>\n")
     # v2.3 · 中文名解析 — 支持纠错提示。若输入无法明确解析，早退并返回候选，不继续跑 22 fetcher。
     from lib.market_router import is_chinese_name
     ti = None

--- a/skills/deep-analysis/scripts/run_real_test.py
+++ b/skills/deep-analysis/scripts/run_real_test.py
@@ -1468,6 +1468,25 @@ def stage1(ticker: str) -> dict:
     """
     # v2.10.1 · 性能模式自动探测（解决 codex + 首次安装机器慢的问题）
     import os
+    # v2.10.2 · 全局 requests timeout 兜底（akshare 内部调用不会卡死）
+    try:
+        from lib import net_timeout_guard  # noqa: F401（import 副作用装 monkey-patch）
+    except Exception as _e:
+        print(f"  ⚠️ timeout guard load failed: {_e}")
+
+    # v2.10.2 · 网络预检（代理/GFW 挂了立即提示，不让 20 fetcher 挨个超时 30 分钟）
+    skip_preflight = os.environ.get("UZI_SKIP_PREFLIGHT") == "1"
+    if not skip_preflight:
+        try:
+            from lib.network_preflight import run_preflight
+            pre = run_preflight(verbose=True, timeout=3.0)
+            # 3 个以上不通 → 强制 lite
+            if pre["critical_failures"] >= 3 and os.environ.get("UZI_LITE") != "0":
+                os.environ["UZI_LITE"] = "1"
+                print(f"   ⚡ 网络严重受限，自动切 lite 模式防止挂太久\n")
+        except Exception as _e:
+            print(f"  ⚠️ preflight failed (非致命): {_e}")
+
     is_lite, lite_reason = _detect_lite_mode()
     if is_lite:
         os.environ["UZI_LITE"] = "1"  # 下游 fetcher 能读

--- a/skills/deep-analysis/scripts/run_real_test.py
+++ b/skills/deep-analysis/scripts/run_real_test.py
@@ -157,8 +157,22 @@ def collect_raw_data(ticker: str, max_workers: int = 6, resume: bool = True) -> 
     # ── Wave 2: all other 19 fetchers in parallel ──
     # v2.6 · 加 per-fetcher timeout + overall timeout 防止 hang 卡死整条流水线
     # v2.6 · resume: 已缓存有效的 dim 直接复用，不重新调 fetcher
+    # v2.10.2 · 根据 analysis_profile 决定跑哪几维（lite 只跑核心 7 维）
     wave2_start = time.time()
+    try:
+        from lib.analysis_profile import get_profile as _get_profile
+        _profile = _get_profile()
+        enabled_dims = _profile.fetchers_enabled
+    except Exception:
+        enabled_dims = None
     all_others = [(m, d, a) for m, d, a in FETCHER_MAP if d != "0_basic"]
+    # 按 profile 过滤（None 时不过滤，向后兼容）
+    if enabled_dims is not None:
+        before = len(all_others)
+        all_others = [(m, d, a) for m, d, a in all_others if d in enabled_dims]
+        skipped_profile = before - len(all_others)
+        if skipped_profile > 0:
+            print(f"  [profile] {_profile.depth} 模式跳过 {skipped_profile} 个维度")
     # 分流
     others = []
     skipped_cached = []
@@ -265,14 +279,12 @@ def collect_raw_data(ticker: str, max_workers: int = 6, resume: bool = True) -> 
     def _fund_holders():
         try:
             import fetch_fund_holders
-            # v2.10.1 · 性能优化：默认 limit=20（茅台级大票原先 649 家逐家 akshare
-            # 查询需要 5-10 分钟，对 codex + 首次安装机器是主要耗时瓶颈）。
-            # 大多数分析场景前 20 大基金持仓已能反映机构偏好；需要全量可设
-            # UZI_FUND_LIMIT=all 或 UZI_FUND_LIMIT=<N> 覆盖。
-            import os
-            fl = os.environ.get("UZI_FUND_LIMIT", "20")
-            limit = None if fl in ("all", "none", "None", "0") else int(fl)
-            fh = fetch_fund_holders.main(ticker, limit=limit)
+            # v2.10.1 · 清单 limit 保持 None（全量列出 649 家），慢在 fetch_fund_holders
+            # 内部已改成"头部 top N 算完整 5Y 业绩，其余只列名字"双层策略。
+            # UZI_FUND_STATS_TOP=N 控制几家算完整业绩（默认 20）。
+            # 用户原问题："基金拉全不是直接检索就行了吗" — 对，清单一次 API 就够，
+            # 过去慢是因为每家都跑 5Y NAV 计算，现在只头部跑，其他点 fund_url 看详情。
+            fh = fetch_fund_holders.main(ticker, limit=None)
             return ("fund_managers", (fh.get("data") or {}).get("fund_managers", []), None)
         except Exception as e:
             return ("fund_managers", [], str(e))

--- a/skills/deep-analysis/scripts/tests/test_no_regressions.py
+++ b/skills/deep-analysis/scripts/tests/test_no_regressions.py
@@ -816,6 +816,18 @@ def test_tushare_provider_requires_key():
         if old: os.environ["TUSHARE_TOKEN"] = old
 
 
+def test_direct_http_provider_exists():
+    """v2.10.3 · 直连站点 provider 必须注册（脱离 akshare 包装抓行情）"""
+    from lib import providers
+    p = providers.get("direct_http")
+    assert p is not None, "direct_http provider 未注册"
+    assert p.requires_key is False
+    assert "A" in p.markets and "H" in p.markets and "U" in p.markets
+    # 必须有三级 fallback 入口
+    for method in ("fetch_quote_tencent", "fetch_quote_sina", "fetch_quote"):
+        assert hasattr(p, method), f"direct_http 缺 {method}"
+
+
 def test_parse_ticker_hk_3digit():
     """v2.10.2 · 3 位数字码（如 700/981）必须识别为 HK 不是 A 股"""
     from lib.market_router import parse_ticker

--- a/skills/deep-analysis/scripts/tests/test_no_regressions.py
+++ b/skills/deep-analysis/scripts/tests/test_no_regressions.py
@@ -724,6 +724,45 @@ def test_analysis_profile_env_compat():
     os.environ.pop("UZI_DEPTH", None)
 
 
+# ─── v2.10.2 · 代理/网络挂死的 4 层保护 ──
+def test_ddg_timeout_wrapper():
+    """v2.10.2 · DDGS 必须有硬 timeout（原先无，GFW 挂时卡 30-120s）"""
+    src = (SCRIPTS_DIR / "lib" / "web_search.py").read_text(encoding="utf-8")
+    assert "UZI_DDG_TIMEOUT" in src, "v2.10.2 regression: DDGS 缺 timeout env"
+    assert "concurrent.futures" in src or "_cf" in src, \
+        "v2.10.2 regression: DDGS 必须用线程池硬 kill，不能依赖 DDGS 内部 timeout"
+    # 必须有 timeout 错误返回
+    assert "ddgs: timeout" in src
+
+
+def test_net_timeout_guard_exists():
+    """v2.10.2 · net_timeout_guard 必须存在且 monkey-patch requests"""
+    p = SCRIPTS_DIR / "lib" / "net_timeout_guard.py"
+    assert p.exists(), "v2.10.2 regression: lib/net_timeout_guard.py 缺失"
+    src = p.read_text(encoding="utf-8")
+    assert "install_default_timeout" in src
+    assert "Session.request" in src, "必须 patch Session.request（覆盖所有 akshare 内部调用）"
+    assert "UZI_HTTP_TIMEOUT" in src
+
+
+def test_network_preflight_exists():
+    """v2.10.2 · 网络预检必须存在且覆盖核心域名"""
+    p = SCRIPTS_DIR / "lib" / "network_preflight.py"
+    assert p.exists()
+    src = p.read_text(encoding="utf-8")
+    for d in ("eastmoney", "duckduckgo", "cninfo", "xueqiu"):
+        assert d in src, f"预检必须覆盖 {d} 域名"
+
+
+def test_parse_ticker_hk_3digit():
+    """v2.10.2 · 3 位数字码（如 700/981）必须识别为 HK 不是 A 股"""
+    from lib.market_router import parse_ticker
+    for code in ("700", "981"):
+        r = parse_ticker(code)
+        assert r.market == "H", f"v2.10.2 regression: {code} 应识别为 HK，实际 {r.market}"
+        assert r.full == f"{code.zfill(5)}.HK"
+
+
 def test_prewarm_cache_script_exists():
     """v2.10.2 · prewarm 脚本存在且具有敏感性扫描"""
     p = SCRIPTS_DIR / "prewarm_cache.py"

--- a/skills/deep-analysis/scripts/tests/test_no_regressions.py
+++ b/skills/deep-analysis/scripts/tests/test_no_regressions.py
@@ -645,6 +645,56 @@ def test_stage1_early_exits_on_etf():
         "v2.9.2 regression: ETF 持仓拉取接口未使用"
 
 
+# ─── v2.10.1 · 性能优化：lite mode + ddgs 预算 + fund_holders 默认 20 ──
+def test_fund_holders_default_limit_capped():
+    """v2.10.1 · wave3 默认 limit=20 而不是 None（保护首次安装/Codex）"""
+    src = (SCRIPTS_DIR / "run_real_test.py").read_text(encoding="utf-8")
+    idx = src.find("def _fund_holders")
+    snippet = src[idx:idx + 1200]
+    assert "UZI_FUND_LIMIT" in snippet, \
+        "v2.10.1 regression: wave3 必须支持 UZI_FUND_LIMIT 环境变量"
+    # 默认不应该是 None
+    assert '"20"' in snippet or "= 20" in snippet, \
+        "v2.10.1 regression: UZI_FUND_LIMIT 默认必须是 20（不是 None）"
+
+
+def test_lite_mode_detection_exists():
+    """v2.10.1 · _detect_lite_mode 必须存在"""
+    src = (SCRIPTS_DIR / "run_real_test.py").read_text(encoding="utf-8")
+    assert "_detect_lite_mode" in src, "v2.10.1 regression: 缺 _detect_lite_mode"
+    assert "UZI_LITE" in src
+    assert "UZI_DDG_BUDGET" in src
+
+
+def test_ddg_budget_enforced():
+    """v2.10.1 · search() 必须在超预算时返回 _budget_exceeded 标记并过滤掉"""
+    import os
+    os.environ["UZI_DDG_BUDGET"] = "0"  # 强制超预算
+    try:
+        from importlib import reload
+        from lib import web_search
+        reload(web_search)
+        # 预算为 0，任何未命中 cache 的查询都应该返空
+        results = web_search.search("测试预算 xxxx_unique_probe_q", max_results=3, cache_key_prefix="budget_test")
+        assert isinstance(results, list)
+        # _budget_exceeded 标记不应对外暴露
+        assert not any(r.get("_budget_exceeded") for r in results)
+        state = web_search.get_budget_state()
+        assert state["skipped"] >= 0  # 至少调用过
+    finally:
+        os.environ.pop("UZI_DDG_BUDGET", None)
+
+
+def test_fetch_industry_respects_lite_mode():
+    """v2.10.1 · fetch_industry 在 UZI_LITE=1 时不跑 _dynamic_industry_overview"""
+    src = (SCRIPTS_DIR / "fetch_industry.py").read_text(encoding="utf-8")
+    assert 'UZI_LITE' in src and '_dynamic_industry_overview' in src
+    # 检查早退逻辑
+    idx = src.find('UZI_LITE')
+    snippet = src[idx:idx + 300]
+    assert "dynamic = {}" in snippet, "lite mode 必须让 dynamic 为空"
+
+
 if __name__ == "__main__":
     # Manual runner — no pytest required
     import inspect

--- a/skills/deep-analysis/scripts/tests/test_no_regressions.py
+++ b/skills/deep-analysis/scripts/tests/test_no_regressions.py
@@ -646,16 +646,21 @@ def test_stage1_early_exits_on_etf():
 
 
 # ─── v2.10.1 · 性能优化：lite mode + ddgs 预算 + fund_holders 默认 20 ──
-def test_fund_holders_default_limit_capped():
-    """v2.10.1 · wave3 默认 limit=20 而不是 None（保护首次安装/Codex）"""
-    src = (SCRIPTS_DIR / "run_real_test.py").read_text(encoding="utf-8")
-    idx = src.find("def _fund_holders")
-    snippet = src[idx:idx + 1200]
-    assert "UZI_FUND_LIMIT" in snippet, \
-        "v2.10.1 regression: wave3 必须支持 UZI_FUND_LIMIT 环境变量"
-    # 默认不应该是 None
-    assert '"20"' in snippet or "= 20" in snippet, \
-        "v2.10.1 regression: UZI_FUND_LIMIT 默认必须是 20（不是 None）"
+def test_fund_holders_two_tier_strategy():
+    """v2.10.1 · fetch_fund_holders 必须双层（头部 full + 其余 lite）"""
+    src = (SCRIPTS_DIR / "fetch_fund_holders.py").read_text(encoding="utf-8")
+    assert "_build_row_full" in src and "_build_row_lite" in src, \
+        "v2.10.1 regression: fetch_fund_holders 必须分 full/lite 双路径"
+    assert "UZI_FUND_STATS_TOP" in src, \
+        "v2.10.1 regression: 必须支持 UZI_FUND_STATS_TOP 环境变量控制几家算完整业绩"
+    # lite 行必须是 0 次 akshare 额外调用
+    lite_idx = src.find("def _build_row_lite")
+    lite_end = src.find("\n\n", lite_idx)
+    lite_body = src[lite_idx:lite_end] if lite_end > 0 else src[lite_idx:lite_idx + 2000]
+    assert "compute_fund_stats" not in lite_body, \
+        "v2.10.1 regression: lite 行不应调 compute_fund_stats（0 API 原则）"
+    assert "fetch_fund_manager_name" not in lite_body, \
+        "v2.10.1 regression: lite 行不应调 fetch_fund_manager_name"
 
 
 def test_lite_mode_detection_exists():
@@ -683,6 +688,52 @@ def test_ddg_budget_enforced():
         assert state["skipped"] >= 0  # 至少调用过
     finally:
         os.environ.pop("UZI_DDG_BUDGET", None)
+
+
+def test_analysis_profile_three_tiers():
+    """v2.10.2 · 三档深度 profile 必须存在且差异清晰"""
+    from lib.analysis_profile import get_profile, DEPTH_LITE, DEPTH_MEDIUM, DEPTH_DEEP
+    lite = get_profile(DEPTH_LITE)
+    mid = get_profile(DEPTH_MEDIUM)
+    deep = get_profile(DEPTH_DEEP)
+    # 档位差异必须显著
+    assert len(lite.fetchers_enabled) < len(mid.fetchers_enabled) == len(deep.fetchers_enabled)
+    assert lite.investors_count < mid.investors_count == deep.investors_count
+    assert lite.ddg_budget < mid.ddg_budget < deep.ddg_budget
+    assert lite.fund_stats_top_n < mid.fund_stats_top_n < deep.fund_stats_top_n
+    assert not lite.enable_bull_bear_debate
+    assert not mid.enable_bull_bear_debate
+    assert deep.enable_bull_bear_debate  # deep 独享
+    assert not lite.enable_segmental_model
+    assert deep.enable_segmental_model
+
+
+def test_analysis_profile_env_compat():
+    """UZI_LITE=1 必须向后兼容到 depth=lite"""
+    import os
+    from lib.analysis_profile import get_profile, DEPTH_LITE, DEPTH_MEDIUM
+    # UZI_LITE=1
+    os.environ["UZI_LITE"] = "1"
+    os.environ.pop("UZI_DEPTH", None)
+    assert get_profile().depth == DEPTH_LITE
+    # 显式 UZI_DEPTH 覆盖 UZI_LITE
+    os.environ["UZI_DEPTH"] = "medium"
+    assert get_profile().depth == DEPTH_MEDIUM
+    # 清理
+    os.environ.pop("UZI_LITE", None)
+    os.environ.pop("UZI_DEPTH", None)
+
+
+def test_prewarm_cache_script_exists():
+    """v2.10.2 · prewarm 脚本存在且具有敏感性扫描"""
+    p = SCRIPTS_DIR / "prewarm_cache.py"
+    assert p.exists(), "v2.10.2 regression: prewarm_cache.py 缺失"
+    content = p.read_text(encoding="utf-8")
+    # 必须有安全扫描
+    assert "sanity_check_output" in content, "prewarm 必须做输出敏感性扫描"
+    assert "MX_APIKEY" in content or "sk-" in content, "敏感扫描必须覆盖 API key 模式"
+    # 必须声明不包含敏感信息
+    assert ".env" in content, "prewarm 文档必须明确排除 .env"
 
 
 def test_fetch_industry_respects_lite_mode():

--- a/skills/deep-analysis/scripts/tests/test_no_regressions.py
+++ b/skills/deep-analysis/scripts/tests/test_no_regressions.py
@@ -754,6 +754,68 @@ def test_network_preflight_exists():
         assert d in src, f"预检必须覆盖 {d} 域名"
 
 
+# ─── v2.10.3 · Providers 框架（Tushare/Efinance/BaoStock 适配器） ──
+def test_providers_framework_loads():
+    """v2.10.3 · providers 目录必须存在且核心 provider 已注册"""
+    from lib import providers
+    names = {p.name for p in providers.list_providers()}
+    # 至少 4 个内置 provider
+    assert "akshare" in names, "akshare provider 未注册"
+    assert "efinance" in names, "efinance provider 未注册"
+    assert "tushare" in names, "tushare provider 未注册"
+    assert "baostock" in names, "baostock provider 未注册"
+
+
+def test_provider_chain_failover():
+    """provider chain 必须按优先级返 + 只包含 available 的"""
+    from lib import providers
+    chain = providers.get_provider_chain("financials", market="A")
+    # 至少 akshare 或 baostock 在（测试机两者都装了）
+    assert len(chain) >= 1
+    # 所有返回的都必须 is_available()
+    assert all(p.is_available() for p in chain)
+
+
+def test_provider_env_override():
+    """UZI_PROVIDERS_<DIM> 环境变量可覆盖优先级"""
+    import os
+    from lib import providers
+    os.environ["UZI_PROVIDERS_FINANCIALS"] = "baostock,akshare"
+    try:
+        chain = providers.get_provider_chain("financials", market="A")
+        names = [p.name for p in chain]
+        # baostock 应该在前（如果可用）
+        if "baostock" in names and "akshare" in names:
+            assert names.index("baostock") < names.index("akshare")
+    finally:
+        os.environ.pop("UZI_PROVIDERS_FINANCIALS", None)
+
+
+def test_provider_health_check_api():
+    """health_check 返回统一 dict 结构"""
+    from lib import providers
+    hc = providers.health_check()
+    assert "akshare" in hc
+    for name, info in hc.items():
+        assert "available" in info
+        assert "status" in info
+
+
+def test_tushare_provider_requires_key():
+    """tushare 必须 requires_key=True 且无 token 时 is_available=False"""
+    import os
+    from lib import providers
+    ts = providers.get("tushare")
+    assert ts is not None
+    assert ts.requires_key is True
+    # 无 token
+    old = os.environ.pop("TUSHARE_TOKEN", None)
+    try:
+        assert ts.is_available() is False, "无 TUSHARE_TOKEN 时不该可用"
+    finally:
+        if old: os.environ["TUSHARE_TOKEN"] = old
+
+
 def test_parse_ticker_hk_3digit():
     """v2.10.2 · 3 位数字码（如 700/981）必须识别为 HK 不是 A 股"""
     from lib.market_router import parse_ticker


### PR DESCRIPTION
## Summary
一次性合并近 24 小时的 6 大改动，解决用户反馈的性能/token/韧性/多源需求。

## 用户反馈驱动的改动

1. **\"让用户自己选择思考深度\"** → \`lite/medium/deep\` 三档 + \`--depth\` CLI
2. **\"除了 akshare，tushare 这些能作为备选吗\"** → \`lib/providers/\` 5 个源 auto-failover
3. **Codex 建议 fetch_web_quote.py（未实际提交）** → 我落地为 \`direct_http\` provider
4. **\"基金拉全不是直接检索就行了吗\"** → Top N full + 其余 lite · 5-10min → 30-60s
5. **\"代理、网络不通导致 codex 卡死\"** → 4 层 timeout 保护 · 启动预检 · 最坏 40min → 60s
6. **\"缓存能提前写入吗，别含敏感信息\"** → \`prewarm_cache.py\` 公开数据预热

## Test plan
- [x] 68/68 regression tests pass（新增 13 条）
- [x] direct_http 实测 600519/000001/00700/AAPL 拿到实时价
- [x] lite/medium/deep profile 差异验证
- [x] DDGS 2s 硬 timeout 验证（原先 30-120s）
- [x] 网络预检 5 域 3s 跑完
- [x] parse_ticker HK 3 位码修复（700 → 00700.HK）