### PR TITLE
v2.10.4: Codex 反馈 3 个 bug 修复 · lite 自查兼容 + ETF 早退干净

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "stock-deep-analyzer",
-  "version": "2.10.3",
+  "version": "2.10.4",
   "description": "A股/港股/美股个股深度分析引擎 · 22维数据 × 51位大佬量化评委 × 17种机构级分析方法 · 杀猪盘检测 · Bloomberg风格HTML报告 | A-share / HK / US stock deep-analysis with first-class Chinese-market coverage — 22 data dims × 51-investor jury × 17 institutional methods · trap detection · Bloomberg-style HTML report",
   "author": {
     "name": "FloatFu-true",

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "stock-deep-analyzer",
   "description": "A股/港股/美股个股深度分析引擎 · 22维数据 × 51位大佬量化评委 · 17种机构级分析方法 | A-share / HK / US deep-analysis · 22 dims × 51-investor jury × 17 institutional methods",
-  "version": "2.10.3",
+  "version": "2.10.4",
   "author": {
     "name": "FloatFu-true"
   },

--- a/.version-bump.json
+++ b/.version-bump.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.10.3",
+  "version": "2.10.4",
   "files": [
     ".claude-plugin/plugin.json",
     ".cursor-plugin/plugin.json",

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,5 +1,43 @@
 # Release Notes
 
+## v2.10.4 — 2026-04-17 (lite 自查兼容 + ETF 早退干净)
+
+> **Codex 跑 v2.10.3 反馈的 3 个 bug · 全部修复 + 回归测试**
+
+### 修复
+
+**1. lite 模式与 self-review 规则冲突**
+- 症状：`UZI_DEPTH=lite` 跑完 gate 报 9 个 critical（维度缺失、data 为空）
+- 根因：`check_all_dims_exist` / `check_empty_dims` 硬编码检查全 20 维，不看 profile
+- 修：两个函数现在读 `analysis_profile.get_profile().fetchers_enabled`，只检查启用的维度
+- medium/deep 行为不变（仍强制 20 维）
+
+**2. agent_analysis.json 缺失在 CLI-only 运行误报 critical**
+- 症状：`python run.py` 直跑（无 agent 介入）→ gate 必定 critical，阻止 HTML 生成
+- 修：`check_agent_analysis_exists` 在 `UZI_DEPTH=lite` / `UZI_LITE=1` / `UZI_CLI_ONLY=1` / `CI=true` 时降级为 warning
+- 正常两段式流程（stage1 → agent → stage2）行为不变
+
+**3. ETF 早退逻辑半成功**
+- 症状：`python run.py 512400.SH` → stage1 正确识别 ETF 写 `_resolve_error.json`，但 stage2 仍被调用 → `RuntimeError: Stage 2 缺少数据`
+- 修 A：`run_real_test.main()` 加 `status == "non_stock_security"` 分支，跳过 stage2 并 `return result`
+- 修 B：`run.py` 捕获 `run_analysis(...)` 返回的 `non_stock_security` dict，打印成分股提示后 `sys.exit(0)`
+- 修 B2：中文名路径也加同样检查（指数/ETF 用中文名输入时）
+
+### 回归测试
+
+- 新增 `tests/test_v2_10_4_fixes.py` · 8 个用例覆盖上述 3 个 bug + 正向场景
+- 原 68 个 regression 全绿
+
+### 文件清单
+
+- `skills/deep-analysis/scripts/lib/self_review.py`（profile-aware · 3 处）
+- `skills/deep-analysis/scripts/run_real_test.py`（main() 加 ETF 早退 + 返回 result）
+- `run.py`（两条路径都捕获 non_stock_security 干净退出）
+- `skills/deep-analysis/scripts/tests/test_v2_10_4_fixes.py`（新）
+- 版本号 bump 到 2.10.4
+
+---
+
 ## v2.10.3 — 2026-04-18 (多源 providers 框架 + 三档深度 + 网络韧性)
 
 > **一次性合入近一天积累的所有性能 / 韧性 / 数据源改造**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stock-deep-analyzer",
-  "version": "2.10.3",
+  "version": "2.10.4",
   "description": "A股/港股/美股个股深度分析引擎 · 22维数据 × 51位大佬量化评委 · 17种机构级分析方法 | A-share / HK / US deep-analysis · 22 dims × 51-investor jury × 17 institutional methods",
   "type": "module",
   "author": "FloatFu-true",

--- a/run.py
+++ b/run.py
@@ -322,6 +322,13 @@ def main():
     from lib.market_router import is_chinese_name
     if is_chinese_name(args.ticker) and not args.force_name:
         stage1_result = _stage1(args.ticker)
+        # v2.10.4 · ETF/指数/可转债早退：stage1 已写 _resolve_error.json + 成分股清单
+        if isinstance(stage1_result, dict) and stage1_result.get("status") == "non_stock_security":
+            print(f"\n{'━' * 50}")
+            print(f"🔴 {args.ticker} 是 {stage1_result.get('label', '非个股标的')}，已跳过 stage2。")
+            print(f"   请选择上面列出的成分股之一重跑。")
+            print(f"{'━' * 50}")
+            sys.exit(0)
         if isinstance(stage1_result, dict) and stage1_result.get("status") == "name_not_resolved":
             cands = stage1_result.get("candidates", [])
             print(f"\n{'━' * 50}")
@@ -362,7 +369,21 @@ def main():
             if resolved:
                 args.ticker = resolved
     else:
-        run_analysis(args.ticker)
+        result = run_analysis(args.ticker)
+        # v2.10.4 · ETF/指数/可转债早退（stage1 已输出成分股清单，不生成报告）
+        if isinstance(result, dict) and result.get("status") in ("non_stock_security", "name_not_resolved"):
+            print(f"\n{'━' * 50}")
+            status = result.get("status")
+            if status == "non_stock_security":
+                print(f"🔴 {args.ticker} 是 {result.get('label', '非个股标的')}，已跳过 stage2。")
+                if result.get("top_holdings"):
+                    print(f"   请从上方列出的成分股里选一只重跑，例如：python run.py {result['top_holdings'][0]['code']}")
+                else:
+                    print(f"   {result.get('what_to_do', '请改用个股代码重跑。')}")
+            else:
+                print(f"🔴 {args.ticker} 股票名无法解析")
+            print(f"{'━' * 50}")
+            sys.exit(0)
 
     # 找到生成的报告
     from datetime import datetime

--- a/skills/deep-analysis/scripts/lib/self_review.py
+++ b/skills/deep-analysis/scripts/lib/self_review.py
@@ -79,12 +79,27 @@ def check_industry_mapping_sanity(ctx: dict) -> list[Issue]:
 
 
 def check_all_dims_exist(ctx: dict) -> list[Issue]:
-    """22 维必须都存在（不能完全缺失 key）"""
+    """应跑的维度必须都存在 · v2.10.4 · profile-aware (lite 只查启用的维度)."""
     issues = []
     dims = ctx["dims"]
-    EXPECTED = [f"{i}_" for i in range(20)] + ["20_valuation_models", "21_research_workflow", "22_deep_methods"]
-    # 只检查前 20 个 fetcher 维度
+
+    # v2.10.4 · 按 profile.fetchers_enabled 决定"应跑"的维度集
+    # lite 模式只跑 7 个维度，未启用的不能报 critical missing
     required_numbered = set(range(20))
+    try:
+        from lib.analysis_profile import get_profile
+        profile = get_profile()
+        # profile.fetchers_enabled 形如 {"0_basic", "1_financials", ...}
+        enabled_nums = {
+            int(k.split("_")[0])
+            for k in profile.fetchers_enabled
+            if k[0].isdigit() and k.split("_")[0].isdigit()
+        }
+        if enabled_nums:
+            required_numbered = enabled_nums
+    except Exception:
+        pass  # profile 加载失败，fallback 到全 20 维
+
     present_nums = {int(k.split("_")[0]) for k in dims if k[0].isdigit() and k.split("_")[0].isdigit()}
     missing = required_numbered - present_nums
     if missing:
@@ -93,7 +108,7 @@ def check_all_dims_exist(ctx: dict) -> list[Issue]:
                 severity="critical",
                 category="data",
                 dim=f"{num}_",
-                issue=f"维度 {num} 完全缺失（fetcher 从未运行或崩溃）",
+                issue=f"应跑的维度 {num} 完全缺失（fetcher 从未运行或崩溃）",
                 evidence=f"dims 里没有 key 以 {num}_ 开头",
                 suggested_fix=f"重跑 run.py <ticker> --no-resume 或手动 fetch_X",
             ))
@@ -101,11 +116,33 @@ def check_all_dims_exist(ctx: dict) -> list[Issue]:
 
 
 def check_empty_dims(ctx: dict) -> list[Issue]:
-    """有 key 但 data 完全空的维度"""
+    """有 key 但 data 完全空的维度 · v2.10.4 · profile-aware (lite 只查启用的维度)"""
     issues = []
     dims = ctx["dims"]
+
+    # v2.10.4 · 只检查当前 profile 启用的维度
+    enabled_nums = None
+    try:
+        from lib.analysis_profile import get_profile
+        profile = get_profile()
+        enabled_nums = {
+            int(k.split("_")[0])
+            for k in profile.fetchers_enabled
+            if k[0].isdigit() and k.split("_")[0].isdigit()
+        } or None
+    except Exception:
+        pass
+
     for k, v in sorted(dims.items()):
         if not isinstance(v, dict): continue
+        # 跳过 profile 未启用的维度
+        if enabled_nums is not None and k[0].isdigit():
+            try:
+                num = int(k.split("_")[0])
+                if num not in enabled_nums:
+                    continue
+            except ValueError:
+                pass
         data = v.get("data")
         if data in (None, {}, []):
             # 区分是 timeout 还是真空
@@ -312,20 +349,45 @@ def check_metals_materials_populated(ctx: dict) -> list[Issue]:
 
 
 def check_agent_analysis_exists(ctx: dict) -> list[Issue]:
-    """agent_analysis.json 是否写回（HARD-GATE 的机械化版本）"""
+    """agent_analysis.json 是否写回.
+
+    v2.10.4 · 分两档：
+      - 真实 agent 介入（Claude Code / Codex / Cursor 等）：missing → critical
+      - lite 模式 or CLI 直跑（没 agent）：missing → warning，允许报告生成
+    """
     issues = []
     ag = ctx.get("ag")
+
+    # v2.10.4 · 识别是否处于"无 agent 直跑"模式
+    import os
+    is_cli_only = (
+        os.environ.get("UZI_DEPTH") == "lite"
+        or os.environ.get("UZI_LITE") == "1"
+        or os.environ.get("UZI_CLI_ONLY") == "1"
+        # CI/batch 环境也视为无 agent
+        or os.environ.get("CI") == "true"
+    )
+
     if ag is None:
+        severity = "warning" if is_cli_only else "critical"
+        note = "（lite/CLI 直跑模式可接受）" if is_cli_only else ""
         issues.append(Issue(
-            severity="critical", category="self-check", dim="agent_analysis",
-            issue="agent_analysis.json 不存在，agent 未介入",
+            severity=severity,
+            category="self-check",
+            dim="agent_analysis",
+            issue=f"agent_analysis.json 不存在{note}",
             evidence="file not found",
-            suggested_fix="agent 必须读 panel.json + raw_data.json 后写 agent_analysis.json（含 dim_commentary / panel_insights / great_divide_override）",
+            suggested_fix=(
+                "CLI 直跑无 agent 环境可以忽略此项；"
+                "若走 Claude Code/Codex/Cursor 则 agent 必须读 panel.json + raw_data.json "
+                "后写 agent_analysis.json"
+            ),
         ))
         return issues
     if not ag.get("agent_reviewed"):
         issues.append(Issue(
-            severity="critical", category="self-check", dim="agent_analysis",
+            severity="warning" if is_cli_only else "critical",
+            category="self-check", dim="agent_analysis",
             issue="agent_analysis.agent_reviewed != True",
             evidence=f"agent_reviewed={ag.get('agent_reviewed')}",
             suggested_fix="agent 核查完内容后必须显式设置 agent_reviewed: true",

--- a/skills/deep-analysis/scripts/run_real_test.py
+++ b/skills/deep-analysis/scripts/run_real_test.py
@@ -1904,9 +1904,14 @@ def main(ticker: str = "002273.SZ"):
     # v2.3 · stage1 可能因中文名无法解析而早退，此时不能继续 stage2
     if isinstance(result, dict) and result.get("status") == "name_not_resolved":
         print("\n⚠️  因股票名无法解析，跳过 stage2（不会生成空报告）")
-        return
+        return result
+    # v2.10.4 · stage1 可能因非个股标的（ETF/指数/可转债）而早退，不能继续 stage2
+    if isinstance(result, dict) and result.get("status") == "non_stock_security":
+        print("\n⚠️  非个股标的，跳过 stage2（已输出成分股清单给 agent）")
+        return result
     report_path = stage2(ticker)
     print(f"\n🎯 完整流程结束 · 报告: {report_path}")
+    return report_path
 
 
 if __name__ == "__main__":

--- a/skills/deep-analysis/scripts/tests/test_v2_10_4_fixes.py
+++ b/skills/deep-analysis/scripts/tests/test_v2_10_4_fixes.py
@@ -1,0 +1,173 @@
+"""Regression tests for v2.10.4 fixes (Codex-reported bugs).
+
+Bugs:
+1. lite mode conflicts with self-review → 9 critical issues because missing dims
+2. agent_analysis.json missing always triggers critical even in CLI-only runs
+3. ETF early-exit half-broken → `RuntimeError: Stage 2 缺少数据` after 512400 resolve
+"""
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT))
+
+
+# ─── Fix 1 & 3: self-review profile-aware ───
+
+def _make_dims(nums):
+    return {f"{n}_fake": {"data": {"ok": True}} for n in nums}
+
+
+def _reset_profile_env():
+    for k in ("UZI_DEPTH", "UZI_LITE", "UZI_CLI_ONLY"):
+        os.environ.pop(k, None)
+
+
+def test_check_all_dims_lite_respects_profile():
+    """Fix 1 · lite mode must not flag skipped dims as 'completely missing'."""
+    _reset_profile_env()
+    os.environ["UZI_DEPTH"] = "lite"
+    # Force reload profile singleton (analysis_profile caches)
+    import importlib
+    import lib.analysis_profile as ap
+    importlib.reload(ap)
+    import lib.self_review as sr
+    importlib.reload(sr)
+
+    p = ap.get_profile()
+    enabled = {int(k.split("_")[0]) for k in p.fetchers_enabled if k[0].isdigit()}
+    ctx = {"dims": _make_dims(enabled), "market": "A", "ag": {}}
+    issues = sr.check_all_dims_exist(ctx)
+    assert len(issues) == 0, f"lite should not report missing dims; got {[i.issue for i in issues]}"
+    _reset_profile_env()
+
+
+def test_check_empty_dims_lite_respects_profile():
+    """Fix 3 · lite mode must not report empty critical on dims it never ran."""
+    _reset_profile_env()
+    os.environ["UZI_DEPTH"] = "lite"
+    import importlib
+    import lib.analysis_profile as ap
+    importlib.reload(ap)
+    import lib.self_review as sr
+    importlib.reload(sr)
+
+    p = ap.get_profile()
+    enabled = {int(k.split("_")[0]) for k in p.fetchers_enabled if k[0].isdigit()}
+    # All enabled dims have good data — no issues expected
+    ctx = {"dims": _make_dims(enabled), "market": "A", "ag": {}}
+    issues = sr.check_empty_dims(ctx)
+    assert len(issues) == 0
+    _reset_profile_env()
+
+
+def test_check_all_dims_medium_still_reports_missing():
+    """Medium / default profile must still enforce all 20 dims (regression guard)."""
+    _reset_profile_env()
+    import importlib
+    import lib.analysis_profile as ap
+    importlib.reload(ap)
+    import lib.self_review as sr
+    importlib.reload(sr)
+
+    ctx = {"dims": _make_dims([0, 1, 2]), "market": "A", "ag": {}}
+    issues = sr.check_all_dims_exist(ctx)
+    assert len(issues) > 10, "medium must still flag missing dims"
+
+
+# ─── Fix 2: agent_analysis missing warning vs critical ───
+
+def test_agent_analysis_missing_downgrades_in_lite():
+    _reset_profile_env()
+    os.environ["UZI_DEPTH"] = "lite"
+    import importlib
+    import lib.self_review as sr
+    importlib.reload(sr)
+
+    ctx = {"dims": {}, "market": "A", "ag": None}
+    issues = sr.check_agent_analysis_exists(ctx)
+    assert len(issues) == 1
+    assert issues[0].severity == "warning", (
+        f"lite mode should downgrade missing agent_analysis to warning, got {issues[0].severity}"
+    )
+    _reset_profile_env()
+
+
+def test_agent_analysis_missing_critical_in_medium():
+    _reset_profile_env()
+    import importlib
+    import lib.self_review as sr
+    importlib.reload(sr)
+
+    ctx = {"dims": {}, "market": "A", "ag": None}
+    issues = sr.check_agent_analysis_exists(ctx)
+    assert len(issues) == 1
+    assert issues[0].severity == "critical"
+
+
+def test_agent_analysis_missing_downgrades_with_cli_only_env():
+    _reset_profile_env()
+    os.environ["UZI_CLI_ONLY"] = "1"
+    import importlib
+    import lib.self_review as sr
+    importlib.reload(sr)
+
+    ctx = {"dims": {}, "market": "A", "ag": None}
+    issues = sr.check_agent_analysis_exists(ctx)
+    assert issues[0].severity == "warning"
+    _reset_profile_env()
+
+
+# ─── Fix 4: ETF early-exit from main() ───
+
+def test_main_returns_early_on_non_stock_security(monkeypatch):
+    """run_real_test.main() must NOT call stage2 when stage1 returns non_stock_security."""
+    import run_real_test as rrt
+
+    etf_result = {
+        "status": "non_stock_security",
+        "security_type": "etf",
+        "ticker": "512400.SH",
+        "label": "ETF 基金",
+        "top_holdings": [{"rank": 1, "code": "601899.SH", "name": "紫金矿业"}],
+    }
+
+    stage2_called = {"flag": False}
+
+    def fake_stage1(_ticker):
+        return etf_result
+
+    def fake_stage2(_ticker):
+        stage2_called["flag"] = True
+        raise RuntimeError("stage2 must not be called for ETF")
+
+    monkeypatch.setattr(rrt, "stage1", fake_stage1)
+    monkeypatch.setattr(rrt, "stage2", fake_stage2)
+
+    result = rrt.main("512400.SH")
+    assert stage2_called["flag"] is False, "stage2 should NOT be called for non_stock_security"
+    assert isinstance(result, dict)
+    assert result.get("status") == "non_stock_security"
+
+
+def test_main_returns_early_on_name_not_resolved(monkeypatch):
+    """Existing behavior preserved."""
+    import run_real_test as rrt
+
+    err = {"status": "name_not_resolved", "candidates": []}
+    stage2_called = {"flag": False}
+
+    monkeypatch.setattr(rrt, "stage1", lambda _t: err)
+
+    def fake_stage2(_t):
+        stage2_called["flag"] = True
+
+    monkeypatch.setattr(rrt, "stage2", fake_stage2)
+
+    rrt.main("不存在的股票")
+    assert stage2_called["flag"] is False


### PR DESCRIPTION
## Summary

Codex 跑 v2.10.3 真机测试反馈的 3 个 bug · 全部修复 + 回归测试

- **Fix 1** · lite 模式 self-review 冲突：`check_all_dims_exist` + `check_empty_dims` 现在 profile-aware，只检查当前档位启用的维度
- **Fix 2** · `agent_analysis.json` 缺失在 CLI 直跑时降级为 warning（原先必报 critical 阻止 HTML 生成）
- **Fix 3** · ETF 早退干净：`run_real_test.main()` + `run.py` 双路径都捕获 `status=non_stock_security`，不再抛 `RuntimeError: Stage 2 缺少数据`

## Test plan

- [x] `pytest tests/` — 76 通过 (68 原 + 8 新)
- [x] 新增 `tests/test_v2_10_4_fixes.py` 8 个用例覆盖：
  - lite 不误报缺失维度
  - lite 不误报 empty critical
  - medium/default 仍强制 20 维（回归护栏）
  - lite / CLI_ONLY / CI 下 agent_analysis 缺失降级为 warning
  - 默认下 agent_analysis 缺失仍 critical
  - ETF 早退时 stage2 绝不被调用
- [x] 版本 bump: 2.10.3 → 2.10.4

🤖 Generated with [Claude Code](https://claude.com/claude-code)