### PR TITLE
v2.10.5: coverage profile-aware + CLI 直跑 HTML 生成

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "stock-deep-analyzer",
-  "version": "2.10.4",
+  "version": "2.10.5",
   "description": "A股/港股/美股个股深度分析引擎 · 22维数据 × 51位大佬量化评委 × 17种机构级分析方法 · 杀猪盘检测 · Bloomberg风格HTML报告 | A-share / HK / US stock deep-analysis with first-class Chinese-market coverage — 22 data dims × 51-investor jury × 17 institutional methods · trap detection · Bloomberg-style HTML report",
   "author": {
     "name": "FloatFu-true",

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "stock-deep-analyzer",
   "description": "A股/港股/美股个股深度分析引擎 · 22维数据 × 51位大佬量化评委 · 17种机构级分析方法 | A-share / HK / US deep-analysis · 22 dims × 51-investor jury × 17 institutional methods",
-  "version": "2.10.4",
+  "version": "2.10.5",
   "author": {
     "name": "FloatFu-true"
   },

--- a/.version-bump.json
+++ b/.version-bump.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.10.4",
+  "version": "2.10.5",
   "files": [
     ".claude-plugin/plugin.json",
     ".cursor-plugin/plugin.json",

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,10 +1,12 @@
 # Release Notes
 
-## v2.10.5 — 2026-04-18 (coverage threshold profile-aware · v2.10.4 遗漏补丁)
+## v2.10.5 — 2026-04-18 (coverage threshold profile-aware + CLI 直跑 HTML 生成)
+
+> **本地真机测试发现 v2.10.4 还有 3 处漏修 · 一次性补完**
 
 > **Codex 跑 v2.10.4 真机测试再次反馈：lite 模式在网络差时仍被 self-review block**
 
-### Codex 测试发现的遗漏
+### 本地真机测试发现的 3 处遗漏
 
 v2.10.4 修了 `check_all_dims_exist` / `check_empty_dims` / `check_agent_analysis_exists` 三处，但漏了 **`check_coverage_threshold`**：
 
@@ -14,18 +16,37 @@ v2.10.4 修了 `check_all_dims_exist` / `check_empty_dims` / `check_agent_analys
 
 ### 修复
 
-`check_coverage_threshold` (lib/self_review.py) · 两处改动：
+**1. `check_coverage_threshold` profile-aware**（lib/self_review.py）
+- Profile-aware 分母 — 只算当前档位启用维度的 `CRITICAL_CHECKS` 项
+- CLI-only / lite 模式 `< 40%` 的 critical 降为 warning（CLI 直跑无 agent 可补数据）
 
-1. **Profile-aware 分母** — 只算当前档位启用维度的 `CRITICAL_CHECKS` 项
-2. **CLI-only / lite 模式降级** — `< 40%` 的 critical 降为 warning（CLI 直跑无 agent 可补数据，阻止 HTML 没意义，改为 warning 继续出报告供参考）
+**2. run.py 自动标记为 CLI 直跑**（run.py）
+- `run.py` 在 main() 开头设 `UZI_CLI_ONLY=1`
+- 理由：agent 流程走 stage1/stage2 直接调用，不经 run.py；run.py 只服务人/CI
+- 效果：medium/deep 模式下 CLI 直跑 `agent_analysis.json` 缺失也降为 warning，能出报告
+
+**3. `render_fund_managers` None 字段崩溃**（assemble_report.py:1844）
+- 症状：`TypeError: '>' not supported between 'NoneType' and 'int'`
+- 根因：v2.10.2 fund_holders 双层策略下，rest lite 基金的 `return_5y/max_drawdown/sharpe` 为 None，不是 0。`m.get("return_5y", 0)` 不能处理显式 None
+- 修：`m.get("return_5y") or 0` 统一兜底（5 个字段）
 
 ### 回归测试
 
-- 新增 3 个用例 · `test_v2_10_4_fixes.py`:
+- 新增 4 个用例 · `test_v2_10_4_fixes.py`:
   - `test_coverage_critical_downgrades_in_lite` — lite + 17% coverage → warning ✅
   - `test_coverage_critical_preserved_in_medium` — medium + 17% coverage → critical ✅ (回归护栏)
   - `test_coverage_profile_aware_denominator` — lite + 启用维度全满 → 0 issues ✅
-- 原 76 个 regression 全绿 → **79 passed**
+  - `test_run_py_sets_cli_only_env` — run.py 源码含 `UZI_CLI_ONLY=1` setdefault ✅
+- 原 76 个 regression 全绿 → **80 passed**
+
+### 真机验证（local）
+
+| 场景 | v2.10.4 | v2.10.5 |
+|---|---|---|
+| `run.py 600519.SH --depth lite` | ❌ critical block HTML | ✅ warning, HTML ~130s |
+| `run.py 002273.SZ --depth medium` | ❌ agent_analysis critical | ✅ warning, HTML ~60s (cached) |
+| `run.py 00700.HK --depth lite` | ✅ (恰好擦边过) | ✅ 稳 |
+| `run.py 512400.SH` (ETF) | ✅ 早退 | ✅ 早退，提示成分股 |
 
 ---
 

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,5 +1,34 @@
 # Release Notes
 
+## v2.10.5 — 2026-04-18 (coverage threshold profile-aware · v2.10.4 遗漏补丁)
+
+> **Codex 跑 v2.10.4 真机测试再次反馈：lite 模式在网络差时仍被 self-review block**
+
+### Codex 测试发现的遗漏
+
+v2.10.4 修了 `check_all_dims_exist` / `check_empty_dims` / `check_agent_analysis_exists` 三处，但漏了 **`check_coverage_threshold`**：
+
+- 症状：`python run.py 600519.SH --depth lite` → coverage 17%（3/18）→ critical → block HTML 生成
+- 根因：`check_coverage_threshold` 用全 18 项 `CRITICAL_CHECKS` 做分母，不看 profile。lite 只跑 7 维，结构性偏低
+- 对比：`00700.HK` 同样 lite 跑出 44% → warning → HTML 生成 ✅（只是阈值擦边过）
+
+### 修复
+
+`check_coverage_threshold` (lib/self_review.py) · 两处改动：
+
+1. **Profile-aware 分母** — 只算当前档位启用维度的 `CRITICAL_CHECKS` 项
+2. **CLI-only / lite 模式降级** — `< 40%` 的 critical 降为 warning（CLI 直跑无 agent 可补数据，阻止 HTML 没意义，改为 warning 继续出报告供参考）
+
+### 回归测试
+
+- 新增 3 个用例 · `test_v2_10_4_fixes.py`:
+  - `test_coverage_critical_downgrades_in_lite` — lite + 17% coverage → warning ✅
+  - `test_coverage_critical_preserved_in_medium` — medium + 17% coverage → critical ✅ (回归护栏)
+  - `test_coverage_profile_aware_denominator` — lite + 启用维度全满 → 0 issues ✅
+- 原 76 个 regression 全绿 → **79 passed**
+
+---
+
 ## v2.10.4 — 2026-04-17 (lite 自查兼容 + ETF 早退干净)
 
 > **Codex 跑 v2.10.3 反馈的 3 个 bug · 全部修复 + 回归测试**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stock-deep-analyzer",
-  "version": "2.10.4",
+  "version": "2.10.5",
   "description": "A股/港股/美股个股深度分析引擎 · 22维数据 × 51位大佬量化评委 · 17种机构级分析方法 | A-share / HK / US deep-analysis · 22 dims × 51-investor jury × 17 institutional methods",
   "type": "module",
   "author": "FloatFu-true",

--- a/run.py
+++ b/run.py
@@ -254,6 +254,11 @@ def main():
                         help="v2.10.2 · 思考深度 · lite(1-2min) / medium(5-8min · 默认) / deep(15-20min · 含 Bull-Bear 辩论 + Segmental)")
     args = parser.parse_args()
 
+    # v2.10.5 · run.py 是 CLI 直跑入口（agent 流程走 stage1/stage2 直接调用，不经 run.py）。
+    # 设 UZI_CLI_ONLY=1 让 self_review 对 agent_analysis.json 缺失 / 低 coverage 做宽容处理
+    # （降级为 warning，仍出报告）。
+    os.environ.setdefault("UZI_CLI_ONLY", "1")
+
     # v2.10.2 · 深度选择（优先级: --depth > UZI_DEPTH env > UZI_LITE env > 默认 medium）
     try:
         sys.path.insert(0, str(Path(__file__).parent / "skills" / "deep-analysis" / "scripts"))

--- a/skills/deep-analysis/scripts/assemble_report.py
+++ b/skills/deep-analysis/scripts/assemble_report.py
@@ -1832,11 +1832,12 @@ def render_fund_managers(managers: list) -> str:
         trend_color = COLOR_BULL if trend == "加仓" else COLOR_BEAR if trend == "减仓" else COLOR_MUTED
         trend_icon = "📈" if trend == "加仓" else "📉" if trend == "减仓" else "➡️"
 
-        ret_5y = m.get("return_5y", 0)
-        ann_5y = m.get("annualized_5y", 0)
-        max_dd = m.get("max_drawdown", 0)
-        sharpe = m.get("sharpe", 0)
-        peer_rank = m.get("peer_rank_pct", 50)
+        # v2.10.5 · lite 档 fund_managers 前 N 个有完整业绩，其余只有列表信息 → 数值字段可为 None
+        ret_5y = m.get("return_5y") or 0
+        ann_5y = m.get("annualized_5y") or 0
+        max_dd = m.get("max_drawdown") or 0
+        sharpe = m.get("sharpe") or 0
+        peer_rank = m.get("peer_rank_pct") or 50
 
         nav = m.get("nav_history", [])
         nav_spark = svg_sparkline(nav, width=280, height=50, color=COLOR_BULL if nav and nav[-1] > nav[0] else COLOR_BEAR) if nav else ""

--- a/skills/deep-analysis/scripts/lib/self_review.py
+++ b/skills/deep-analysis/scripts/lib/self_review.py
@@ -248,16 +248,73 @@ def check_panel_non_empty(ctx: dict) -> list[Issue]:
 
 
 def check_coverage_threshold(ctx: dict) -> list[Issue]:
-    """_integrity.coverage_pct 必须 >= 60%"""
+    """_integrity.coverage_pct 必须 >= 60% · v2.10.5 · profile-aware + CLI 宽容.
+
+    修正 v2.10.4 遗漏：`check_all_dims_exist` / `check_empty_dims` 已 profile-aware，
+    但 `check_coverage_threshold` 之前仍用全 18 项 CRITICAL_CHECKS 分母 →
+    lite 模式（只跑 7 维）结构性判定 critical（600519 跑出 3/18=17% → block HTML）。
+
+    修复：
+    1. 用 profile.fetchers_enabled 过滤 CRITICAL_CHECKS，分母只算启用维度
+    2. 在 CLI-only / lite 模式下，critical 降级为 warning（CLI 直跑没 agent 补数据，
+       阻止 HTML 没意义；报告里仍会显示 warning 提醒用户）
+    """
     issues = []
     integrity = ctx["raw"].get("_integrity") or {}
     pct = integrity.get("coverage_pct", 100)
+    missing_critical_list = integrity.get("missing_critical", [])
+
+    # v2.10.5 · profile-aware 重算 coverage（仅当 profile 可用）
+    try:
+        from lib.analysis_profile import get_profile
+        from lib.data_integrity import CRITICAL_CHECKS
+        profile = get_profile()
+        enabled = profile.fetchers_enabled
+        raw_dims = ctx.get("raw", {}).get("dimensions", {}) or {}
+        # 只算 profile 启用维度的检查项
+        filtered_total = 0
+        filtered_passed = 0
+        for dim_key, path, _label, _crit in CRITICAL_CHECKS:
+            if dim_key not in enabled:
+                continue
+            filtered_total += 1
+            dim = raw_dims.get(dim_key) or {}
+            data = dim.get("data") or {}
+            # 复用 data_integrity._is_missing 逻辑
+            from lib.data_integrity import _get, _is_missing
+            val = _get(data, path)
+            if not _is_missing(val):
+                filtered_passed += 1
+        if filtered_total:
+            pct = round(filtered_passed / filtered_total * 100, 0)
+            # 过滤后的 missing_critical 也要重算
+            missing_critical_list = [
+                m for m in missing_critical_list if m.get("dim") in enabled
+            ]
+    except Exception:
+        pass  # 无 profile 模块，fallback 原逻辑
+
     if pct < 60:
+        # 默认严重度：< 40% critical；否则 warning
+        severity = "critical" if pct < 40 else "warning"
+        # CLI-only / lite 模式下降级：即使 critical 也降 warning（无 agent 可补）
+        import os as _os
+        is_cli_only = (
+            _os.environ.get("UZI_DEPTH") == "lite"
+            or _os.environ.get("UZI_LITE") == "1"
+            or _os.environ.get("UZI_CLI_ONLY") == "1"
+            or _os.environ.get("CI") == "true"
+        )
+        if severity == "critical" and is_cli_only:
+            severity = "warning"
+            note = "（lite/CLI 直跑模式降级为 warning，仍出报告供参考）"
+        else:
+            note = ""
         issues.append(Issue(
-            severity="critical" if pct < 40 else "warning",
+            severity=severity,
             category="data", dim="overall",
-            issue=f"数据完整性仅 {pct:.0f}%（< 60% 不该出报告）",
-            evidence=f"coverage_pct={pct}, missing_critical={integrity.get('missing_critical', [])[:3]}",
+            issue=f"数据完整性仅 {pct:.0f}%（< 60% 不该出报告）" + note,
+            evidence=f"coverage_pct={pct}, missing_critical={missing_critical_list[:3]}",
             suggested_fix="agent 用 WebSearch / mx_api 补齐 missing_critical 维度，重跑 stage2",
         ))
     return issues

--- a/skills/deep-analysis/scripts/tests/test_v2_10_4_fixes.py
+++ b/skills/deep-analysis/scripts/tests/test_v2_10_4_fixes.py
@@ -228,6 +228,21 @@ def test_coverage_critical_preserved_in_medium():
     assert issues[0].severity == "critical"
 
 
+def test_run_py_sets_cli_only_env():
+    """Fix (v2.10.5) · run.py is CLI direct entrypoint · should auto-set UZI_CLI_ONLY=1.
+
+    Agent flow calls stage1/stage2 directly; only humans/CI use run.py. So run.py
+    must tell self_review it's CLI-only so agent_analysis.json missing gets warning
+    (not critical that blocks HTML).
+    """
+    run_py = Path(__file__).resolve().parent.parent.parent.parent.parent / "run.py"
+    assert run_py.exists()
+    src = run_py.read_text(encoding="utf-8")
+    assert 'os.environ.setdefault("UZI_CLI_ONLY", "1")' in src, (
+        "run.py must set UZI_CLI_ONLY=1 so CLI direct runs produce HTML"
+    )
+
+
 def test_coverage_profile_aware_denominator():
     """Fix (v2.10.5) · denominator should exclude dims not in profile.
 

--- a/skills/deep-analysis/scripts/tests/test_v2_10_4_fixes.py
+++ b/skills/deep-analysis/scripts/tests/test_v2_10_4_fixes.py
@@ -171,3 +171,108 @@ def test_main_returns_early_on_name_not_resolved(monkeypatch):
 
     rrt.main("不存在的股票")
     assert stage2_called["flag"] is False
+
+
+# ─── v2.10.5 · Codex 反馈 Test 2 新发现：check_coverage_threshold 不 profile-aware ───
+
+def test_coverage_critical_downgrades_in_lite():
+    """Fix (v2.10.5) · lite mode should not block HTML on coverage_pct<40 (no agent to fix)."""
+    _reset_profile_env()
+    os.environ["UZI_DEPTH"] = "lite"
+    import importlib
+    import lib.analysis_profile as ap
+    importlib.reload(ap)
+    import lib.self_review as sr
+    importlib.reload(sr)
+
+    ctx = {
+        "raw": {
+            "_integrity": {
+                "coverage_pct": 17,
+                "missing_critical": [
+                    {"dim": "0_basic", "path": "name", "label": "公司名称"}
+                ],
+            },
+            "dimensions": {},
+        },
+        "dims": {}, "market": "A", "ag": None,
+    }
+    issues = sr.check_coverage_threshold(ctx)
+    assert len(issues) == 1
+    assert issues[0].severity == "warning", (
+        f"lite mode should downgrade low coverage to warning, got {issues[0].severity}"
+    )
+    _reset_profile_env()
+
+
+def test_coverage_critical_preserved_in_medium():
+    """Medium/default must still critical on low coverage (regression guard)."""
+    _reset_profile_env()
+    import importlib
+    import lib.analysis_profile as ap
+    importlib.reload(ap)
+    import lib.self_review as sr
+    importlib.reload(sr)
+
+    ctx = {
+        "raw": {
+            "_integrity": {
+                "coverage_pct": 17,
+                "missing_critical": [{"dim": "0_basic", "path": "name", "label": "x"}],
+            },
+            "dimensions": {},
+        },
+        "dims": {}, "market": "A", "ag": None,
+    }
+    issues = sr.check_coverage_threshold(ctx)
+    assert issues[0].severity == "critical"
+
+
+def test_coverage_profile_aware_denominator():
+    """Fix (v2.10.5) · denominator should exclude dims not in profile.
+
+    With lite (7 dims: 0_basic, 1_financials, 2_kline, 10_valuation, 11_governance,
+    15_events, 16_lhb), CRITICAL_CHECKS items for 7_industry + 14_moat should be
+    excluded → fully-populated lite dims should compute ~100% coverage.
+    """
+    _reset_profile_env()
+    os.environ["UZI_DEPTH"] = "lite"
+    import importlib
+    import lib.analysis_profile as ap
+    importlib.reload(ap)
+    import lib.self_review as sr
+    importlib.reload(sr)
+
+    # Realistic raw: all lite dims have their CRITICAL_CHECKS fields populated
+    dims = {
+        "0_basic": {"data": {
+            "name": "贵州茅台", "price": 1500, "industry": "白酒", "market_cap": 18000,
+            "pe_ttm": 25, "pb": 8.5,
+        }},
+        "1_financials": {"data": {
+            "roe_history": [30, 28, 25],
+            "revenue_history": [1000, 900, 800],
+            "net_profit_history": [500, 400, 350],
+            "financial_health": {"ok": True},
+        }},
+        "2_kline": {"data": {
+            "stage": "牛二", "ma_align": "多头", "macd": "金叉",
+        }},
+        "10_valuation": {"data": {
+            "pe": 25, "pe_quantile": 0.6, "pb_quantile": 0.7,
+        }},
+    }
+    ctx = {
+        "raw": {
+            "_integrity": {"coverage_pct": 80, "missing_critical": []},  # stale
+            "dimensions": dims,
+        },
+        "dims": dims, "market": "A", "ag": None,
+    }
+    issues = sr.check_coverage_threshold(ctx)
+    # With all enabled-dim fields filled, recomputed pct should be high enough
+    # that check fires no issue (pct >= 60)
+    assert len(issues) == 0, (
+        f"lite with full enabled-dim data should produce no coverage issues; got {[i.issue for i in issues]}"
+    )
+    _reset_profile_env()


### PR DESCRIPTION
## Summary

本地真机测试发现 v2.10.4 还有 3 处漏修 · 一次性补完：

- **Fix 1** · `check_coverage_threshold` profile-aware（lite 不再结构性偏低）+ CLI/lite 下 critical 降为 warning
- **Fix 2** · `run.py` 自动 `UZI_CLI_ONLY=1` — medium/deep 模式 CLI 直跑也出报告（agent 流程走 stage1/stage2 不经 run.py）
- **Fix 3** · `render_fund_managers` None 字段兜底（v2.10.2 fund_holders 双层策略下 rest lite 基金字段为 None 导致 TypeError）

## 真机验证

| 场景 | v2.10.4 | v2.10.5 |
|---|---|---|
| 600519.SH lite | ❌ critical block HTML | ✅ HTML 生成 ~130s |
| 002273.SZ medium CLI | ❌ agent_analysis critical | ✅ HTML ~60s (cached) |
| 00700.HK lite | ✅ (擦边过) | ✅ 稳 |
| 512400.SH ETF | ✅ 早退 | ✅ 早退 |
| pytest | 79 passed | 80 passed |

## Test plan

- [x] pytest tests/ — 80 passed
- [x] 真机 600519.SH lite — HTML 生成，critical=0
- [x] 真机 002273.SZ medium — HTML 生成，critical=0
- [x] 真机 512400.SH ETF — 早退 exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)