### PR TITLE
v2.10.6: providers 框架实际落地 · Tushare kline + health CLI

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "stock-deep-analyzer",
-  "version": "2.10.5",
+  "version": "2.10.6",
   "description": "A股/港股/美股个股深度分析引擎 · 22维数据 × 51位大佬量化评委 × 17种机构级分析方法 · 杀猪盘检测 · Bloomberg风格HTML报告 | A-share / HK / US stock deep-analysis with first-class Chinese-market coverage — 22 data dims × 51-investor jury × 17 institutional methods · trap detection · Bloomberg-style HTML report",
   "author": {
     "name": "FloatFu-true",

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "stock-deep-analyzer",
   "description": "A股/港股/美股个股深度分析引擎 · 22维数据 × 51位大佬量化评委 · 17种机构级分析方法 | A-share / HK / US deep-analysis · 22 dims × 51-investor jury × 17 institutional methods",
-  "version": "2.10.5",
+  "version": "2.10.6",
   "author": {
     "name": "FloatFu-true"
   },

--- a/.version-bump.json
+++ b/.version-bump.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.10.5",
+  "version": "2.10.6",
   "files": [
     ".claude-plugin/plugin.json",
     ".cursor-plugin/plugin.json",

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,5 +1,61 @@
 # Release Notes
 
+## v2.10.6 — 2026-04-18 (providers 框架实际落地 + Tushare kline + health CLI)
+
+> **审计发现 v2.10.3 的 providers 框架 0% 被调用**。五个 provider 写好了没 fetcher 用，akshare 挂了照样全部崩。本版把它接进 `data_sources.py` 的 K 线链，让 tushare/efinance 真正作为兜底层参与进来。
+
+### 核心改动
+
+**1. `providers.try_chain(method, dim, market, *args)` 助手**
+- 一行调用拿 `(data, provider_name)`，按 `UZI_PROVIDERS_<DIM>` env 排序
+- `ProviderError` 统一兜底，最后一个 provider 失败才抛
+- 方法未实现的 provider 自动跳过（不崩）
+
+**2. `_kline_a_share_chain` 新增第 7 层兜底 · providers chain**
+- 前 6 层（akshare-em / akshare-sina / baostock / 东财 HTTP / 新浪 HTTP / 腾讯 HTTP）都挂时
+- 自动调 `try_chain("fetch_kline_a", "kline", "A", ...)` 让 tushare/efinance 救场
+- 打印 `[kline] 所有默认源失败，providers/tushare 救场 (XXX 根)` 便于诊断
+
+**3. tushare provider 补齐 `fetch_kline_a`**
+- `pro.daily + adj_factor` 做前复权，字段统一成中文列名
+- 之前只有 financials/top10/lhb/北向，**K 线完全缺**——当 akshare 全线挂时 tushare 也救不了
+- 现在 tushare 是 A 股 K 线的官方级兜底
+
+**4. Provider 健康诊断 CLI：`python -m lib.providers`**
+```
+  name         avail  key req  markets
+  akshare      ✓      no       A,H,U
+  baostock     ✓      no       A
+  direct_http  ✓      no       A,H,U
+  efinance     ✓      no       A,H,U
+  tushare      ✗      yes      A        ← 提示用户如何配 TUSHARE_TOKEN
+```
+- `python -m lib.providers chain A kline` · 看某维度 provider 优先级
+- `UZI_PROVIDERS_KLINE=baostock,akshare` 可交互验证 env 覆盖
+
+### 为什么这版重要
+
+v2.10.3 写好的 5 个 provider 是**死代码**：16 个 fetcher 仍直接 `import akshare as ak`。
+真遇到 GFW 把 push2his/push2.eastmoney 全 timeout 的场景，tushare 已经拿到数据了也白瞎。
+v2.10.6 是第一次让 providers 真正参与救场。下一版会把 basic/financials 也接上。
+
+### 测试
+
+- 8 个新 `tests/test_providers_chain.py` 用例：try_chain 成功/失败/跳过、env 覆盖、tushare 方法存在性、health 结构、Protocol 合规
+- 原 80 用例全绿 → 88 passing
+- CLI 实测 `python -m lib.providers` + `chain A` 两个子命令 OK
+
+### 文件清单
+
+- 新增 `skills/deep-analysis/scripts/lib/providers/__main__.py` (health CLI)
+- 新增 `skills/deep-analysis/scripts/tests/test_providers_chain.py` (8 tests)
+- 修改 `lib/providers/__init__.py` (加 `try_chain`)
+- 修改 `lib/providers/tushare_provider.py` (加 `fetch_kline_a`)
+- 修改 `lib/data_sources.py` (_kline_a_share_chain 第 7 层接 providers)
+- 修改 `docs/DATA-PROVIDERS.md` (诊断 CLI 使用说明)
+
+---
+
 ## v2.10.5 — 2026-04-18 (coverage threshold profile-aware + CLI 直跑 HTML 生成)
 
 > **本地真机测试发现 v2.10.4 还有 3 处漏修 · 一次性补完**

--- a/docs/DATA-PROVIDERS.md
+++ b/docs/DATA-PROVIDERS.md
@@ -2,6 +2,13 @@
 
 UZI-Skill 采用多数据源 + 自动 failover 架构 (v2.10.3 起)。本文档列出**所有能接入**的 providers 及配置方法。
 
+**v2.10.6**：providers chain 正式被 `data_sources._kline_a_share_chain` 调用（此前 0 采用）。诊断工具：
+```bash
+python -m lib.providers              # 看所有 provider 健康度
+python -m lib.providers chain A      # 看 A 股每个维度的优先级链
+UZI_PROVIDERS_KLINE=baostock,akshare python -m lib.providers chain A kline
+```
+
 ## 优先级模型
 
 每个 fetcher 请求时，按这个顺序尝试：

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stock-deep-analyzer",
-  "version": "2.10.5",
+  "version": "2.10.6",
   "description": "A股/港股/美股个股深度分析引擎 · 22维数据 × 51位大佬量化评委 · 17种机构级分析方法 | A-share / HK / US deep-analysis · 22 dims × 51-investor jury × 17 institutional methods",
   "type": "module",
   "author": "FloatFu-true",

--- a/skills/deep-analysis/scripts/lib/data_sources.py
+++ b/skills/deep-analysis/scripts/lib/data_sources.py
@@ -782,6 +782,23 @@ def _kline_a_share_chain(ti: TickerInfo, period: str, start: str, adjust: str) -
         except Exception as e:
             errors.append(f"tencent-direct: {e}")
 
+    # ── 7. v2.10.6 · providers chain (tushare / efinance) 作为最末层兜底
+    # 只在前 6 层都失败后跑：tushare 需要 TUSHARE_TOKEN，efinance 需要 pip
+    try:
+        from lib.providers import try_chain, ProviderError as _PE
+        try:
+            rows, src = try_chain(
+                "fetch_kline_a", dim="kline", market="A",
+                code=code, period=period, start=start, adjust=adjust,
+            )
+            if rows:
+                print(f"    [kline] 所有默认源失败，providers/{src} 救场 ({len(rows)} 根)")
+                return rows
+        except _PE as e:
+            errors.append(f"providers: {e}")
+    except ImportError:
+        pass
+
     # ── All failed
     return [{"_kline_fetch_error": "; ".join(errors) or "no source available"}]
 

--- a/skills/deep-analysis/scripts/lib/providers/__init__.py
+++ b/skills/deep-analysis/scripts/lib/providers/__init__.py
@@ -102,6 +102,57 @@ def get_provider_chain(dim: str, market: str = "A") -> list[Provider]:
     return chain
 
 
+def try_chain(
+    method: str,
+    dim: str,
+    market: str = "A",
+    *args,
+    **kwargs,
+) -> tuple[Any, str]:
+    """按 provider 优先级链依次调用 `method`，返回 (data, provider_name).
+
+    v2.10.6 · 让 fetcher 一行调用就能享受多源 failover：
+
+        from lib.providers import try_chain
+        try:
+            rows, src = try_chain("fetch_kline_a", dim="kline", market="A", code="600519")
+            print(f"拿到 {len(rows)} 根 K 线，来源 {src}")
+        except ProviderError:
+            # 所有 provider 都失败，再走老的硬编码链
+
+    Args:
+      method: provider 上的方法名（如 "fetch_financials_a"）
+      dim:    维度关键字，用于读 UZI_PROVIDERS_<DIM> env 覆盖顺序
+      market: "A" / "H" / "U"
+      *args, **kwargs: 转发给 provider.method(...)
+
+    Raises:
+      ProviderError: 所有可用 provider 都失败（附最后一个错误）
+    """
+    chain = get_provider_chain(dim, market)
+    if not chain:
+        raise ProviderError(f"[{dim}/{market}] 无可用 provider（检查 TUSHARE_TOKEN / pip install）")
+    errors: list[str] = []
+    for p in chain:
+        fn = getattr(p, method, None)
+        if fn is None:
+            errors.append(f"{p.name}: 未实现 {method}")
+            continue
+        try:
+            data = fn(*args, **kwargs)
+            return data, p.name
+        except ProviderError as e:
+            errors.append(f"{p.name}: {e}")
+            continue
+        except Exception as e:
+            # provider 实现里漏抛 ProviderError 的兜底
+            errors.append(f"{p.name}: {type(e).__name__}: {e}")
+            continue
+    raise ProviderError(
+        f"[{dim}/{market}] 所有 provider 都失败: " + " | ".join(errors[:3])
+    )
+
+
 def health_check() -> dict[str, dict]:
     """返回每个 provider 的健康度 + 诊断信息."""
     out = {}

--- a/skills/deep-analysis/scripts/lib/providers/__main__.py
+++ b/skills/deep-analysis/scripts/lib/providers/__main__.py
@@ -1,0 +1,73 @@
+"""Provider health CLI · v2.10.6.
+
+用法：
+    python -m lib.providers            # 所有 provider 健康度
+    python -m lib.providers chain A    # 看 A 股某维度的优先级链
+"""
+from __future__ import annotations
+
+import os
+import sys
+
+from . import health_check, get_provider_chain, list_providers
+
+
+def _banner(title: str) -> None:
+    print("\n" + "─" * 60)
+    print(f"  {title}")
+    print("─" * 60)
+
+
+def cmd_health() -> None:
+    _banner("Provider 健康度 (v2.10.6)")
+    h = health_check()
+    print(f"\n  {'name':12s} {'avail':8s} {'key req':8s} {'markets':10s}  status")
+    print(f"  {'-'*12:12s} {'-'*8:8s} {'-'*8:8s} {'-'*10:10s}  {'-'*30}")
+    for name, info in sorted(h.items()):
+        mk = ",".join(info.get("markets", []))
+        req = "yes" if info.get("requires_key") else "no"
+        avail = "✓" if info.get("available") else "✗"
+        status = info.get("status", "?")
+        print(f"  {name:12s} {avail:8s} {req:8s} {mk:10s}  {status}")
+
+    # 指南
+    _banner("启用建议")
+    if not any(h[n].get("available") for n in ("tushare",)):
+        print("  · Tushare (A 股最稳官方源) 未启用：")
+        print("    1. https://tushare.pro 注册 → 复制 token")
+        print("    2. export TUSHARE_TOKEN=<your>")
+    if not h.get("efinance", {}).get("available"):
+        print("  · efinance 未装：pip install efinance  (0 key · A/H/U 都覆盖)")
+    if not h.get("baostock", {}).get("available"):
+        print("  · baostock 未装：pip install baostock  (0 key · A 股深度历史)")
+    if not h.get("direct_http", {}).get("available"):
+        print("  · direct_http 不可用（requests 缺失）")
+
+
+def cmd_chain(args: list[str]) -> None:
+    market = args[1] if len(args) > 1 else "A"
+    dims = args[2:] if len(args) > 2 else ["kline", "financials", "basic", "lhb"]
+    _banner(f"Provider 优先级链 · market={market}")
+    for d in dims:
+        chain = get_provider_chain(d, market)
+        env_override = os.environ.get(f"UZI_PROVIDERS_{d.upper()}")
+        hint = f"  [UZI_PROVIDERS_{d.upper()}={env_override}]" if env_override else ""
+        names = " → ".join(p.name for p in chain) if chain else "(无可用 provider)"
+        print(f"  {d:14s} {names}{hint}")
+
+
+def main() -> int:
+    argv = sys.argv[1:]
+    if not argv or argv[0] in ("health", "-h"):
+        cmd_health()
+        return 0
+    if argv[0] == "chain":
+        cmd_chain(argv)
+        return 0
+    print(f"未知子命令: {argv[0]}")
+    print("用法: python -m lib.providers [health|chain [market] [dim...]]")
+    return 2
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/skills/deep-analysis/scripts/lib/providers/tushare_provider.py
+++ b/skills/deep-analysis/scripts/lib/providers/tushare_provider.py
@@ -88,6 +88,50 @@ class _TushareProvider:
         except Exception as e:
             raise ProviderError(f"tushare.financials: {e}")
 
+    def fetch_kline_a(self, code: str, period: str = "daily", start: str = "20200101", adjust: str = "qfq") -> list[dict]:
+        """A 股日线 · v2.10.6 新增 · 让 kline chain 有 tushare 作为最后一层兜底.
+
+        pro.daily 给未复权价 + adj_factor；我们做后复权/前复权的朴素还原。
+        字段统一成 data_sources 链里的中文列名，和 akshare 保持一致。
+        """
+        try:
+            pro = self._get_pro()
+            ts_code = self._ts_code(code)
+            # 取日线（未复权）
+            df = pro.daily(ts_code=ts_code, start_date=start)
+            if df is None or df.empty:
+                raise ProviderError("tushare.daily empty")
+            # qfq 处理：拉 adj_factor 做前复权
+            if adjust == "qfq":
+                try:
+                    adj = pro.adj_factor(ts_code=ts_code, start_date=start)
+                    if adj is not None and not adj.empty:
+                        latest_factor = float(adj.iloc[0]["adj_factor"])
+                        df = df.merge(adj[["trade_date", "adj_factor"]], on="trade_date", how="left")
+                        ratio = df["adj_factor"] / latest_factor
+                        for col in ("open", "high", "low", "close", "pre_close"):
+                            if col in df.columns:
+                                df[col] = df[col] * ratio
+                except Exception:
+                    pass  # 复权失败就返回未复权
+            rows = []
+            for _, r in df.sort_values("trade_date").iterrows():
+                rows.append({
+                    "日期": str(r["trade_date"])[:4] + "-" + str(r["trade_date"])[4:6] + "-" + str(r["trade_date"])[6:8],
+                    "开盘": float(r.get("open", 0) or 0),
+                    "收盘": float(r.get("close", 0) or 0),
+                    "最高": float(r.get("high", 0) or 0),
+                    "最低": float(r.get("low", 0) or 0),
+                    "成交量": float(r.get("vol", 0) or 0),
+                    "成交额": float(r.get("amount", 0) or 0),
+                    "涨跌幅": float(r.get("pct_chg", 0) or 0),
+                })
+            return rows
+        except ProviderError:
+            raise
+        except Exception as e:
+            raise ProviderError(f"tushare.kline: {e}")
+
     def fetch_top10_holders(self, code: str) -> list[dict]:
         """前十大流通股东."""
         try:

--- a/skills/deep-analysis/scripts/tests/test_providers_chain.py
+++ b/skills/deep-analysis/scripts/tests/test_providers_chain.py
@@ -1,0 +1,135 @@
+"""Regression tests for v2.10.6 provider chain integration.
+
+Covers:
+- try_chain() success / failover / all-fail
+- get_provider_chain() env override
+- health_check() structure
+- provider method completeness (spot-check)
+"""
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT))
+
+
+def test_health_check_structure():
+    from lib.providers import health_check
+    h = health_check()
+    assert isinstance(h, dict)
+    assert "akshare" in h  # always registered
+    for name, info in h.items():
+        assert "available" in info
+        assert "status" in info
+
+
+def test_get_provider_chain_defaults_to_akshare_first():
+    os.environ.pop("UZI_PROVIDERS_KLINE", None)
+    from lib.providers import get_provider_chain
+    chain = get_provider_chain("kline", "A")
+    # akshare 应该在链首（安装了 akshare 的机器上）
+    if chain:  # only if akshare available
+        assert chain[0].name == "akshare"
+
+
+def test_env_override_reorders_chain(monkeypatch):
+    """Env UZI_PROVIDERS_<DIM> 应改变 chain 顺序."""
+    monkeypatch.setenv("UZI_PROVIDERS_KLINE", "baostock,akshare")
+    from lib.providers import get_provider_chain
+    chain = get_provider_chain("kline", "A")
+    names = [p.name for p in chain]
+    # 两个都可用的环境下，baostock 应先于 akshare
+    if "baostock" in names and "akshare" in names:
+        assert names.index("baostock") < names.index("akshare"), names
+    # 至少有一个匹配到
+    assert len(names) >= 1 or not names  # chain 空在缺依赖时也允许
+
+
+def test_try_chain_returns_data_and_source(monkeypatch):
+    """try_chain 拿到第一个成功的 provider 的返回 + 名字."""
+    import lib.providers as pv
+
+    class _FakeOk:
+        name = "fake_ok"
+        requires_key = False
+        markets = ("A",)
+        def is_available(self): return True
+        def fetch_thing(self, x): return {"got": x}
+
+    class _FakeFail:
+        name = "fake_fail"
+        requires_key = False
+        markets = ("A",)
+        def is_available(self): return True
+        def fetch_thing(self, x): raise pv.ProviderError("nope")
+
+    # Stub _REGISTRY so chain only sees our fakes
+    monkeypatch.setattr(pv, "_REGISTRY", {"fake_fail": _FakeFail(), "fake_ok": _FakeOk()})
+    monkeypatch.setenv("UZI_PROVIDERS_THING", "fake_fail,fake_ok")
+
+    data, src = pv.try_chain("fetch_thing", "thing", "A", "hello")
+    assert data == {"got": "hello"}
+    assert src == "fake_ok"
+
+
+def test_try_chain_raises_when_all_fail(monkeypatch):
+    import lib.providers as pv
+
+    class _F1:
+        name = "f1"; requires_key = False; markets = ("A",)
+        def is_available(self): return True
+        def fetch_x(self): raise pv.ProviderError("boom1")
+
+    class _F2:
+        name = "f2"; requires_key = False; markets = ("A",)
+        def is_available(self): return True
+        def fetch_x(self): raise pv.ProviderError("boom2")
+
+    monkeypatch.setattr(pv, "_REGISTRY", {"f1": _F1(), "f2": _F2()})
+    monkeypatch.setenv("UZI_PROVIDERS_X", "f1,f2")
+    import pytest
+    with pytest.raises(pv.ProviderError) as exc:
+        pv.try_chain("fetch_x", "x", "A")
+    assert "boom1" in str(exc.value) or "boom2" in str(exc.value)
+
+
+def test_try_chain_skips_method_not_implemented(monkeypatch):
+    """Provider 没实现目标方法时应跳过而不是崩溃."""
+    import lib.providers as pv
+
+    class _NoMethod:
+        name = "no_method"; requires_key = False; markets = ("A",)
+        def is_available(self): return True
+        # 故意不实现 fetch_kline_a
+
+    class _HasMethod:
+        name = "has_method"; requires_key = False; markets = ("A",)
+        def is_available(self): return True
+        def fetch_kline_a(self, **kw): return ["row"]
+
+    monkeypatch.setattr(pv, "_REGISTRY", {"no_method": _NoMethod(), "has_method": _HasMethod()})
+    monkeypatch.setenv("UZI_PROVIDERS_KLINE", "no_method,has_method")
+    data, src = pv.try_chain("fetch_kline_a", "kline", "A")
+    assert src == "has_method"
+    assert data == ["row"]
+
+
+def test_tushare_has_kline_method_v2_10_6():
+    """v2.10.6 新增：tushare provider 必须实现 fetch_kline_a（之前缺失）."""
+    from lib.providers import tushare_provider
+    p = tushare_provider._TushareProvider()
+    assert hasattr(p, "fetch_kline_a"), "tushare_provider.fetch_kline_a must exist in v2.10.6"
+    assert callable(p.fetch_kline_a)
+
+
+def test_all_providers_have_is_available():
+    """Protocol 合规：每个 provider 都有 is_available()."""
+    from lib.providers import _REGISTRY
+    for name, p in _REGISTRY.items():
+        assert hasattr(p, "is_available"), f"{name} missing is_available"
+        # 能调（不崩）
+        result = p.is_available()
+        assert isinstance(result, bool), f"{name}.is_available must return bool"


### PR DESCRIPTION
## Summary

审计发现 **v2.10.3 的 providers 框架 0% 被调用** —— 5 个 provider 写好了但 16 个 fetcher 仍直接 \`import akshare as ak\`。GFW 场景下 tushare 明明可用也白搭。本版让 providers 真正落地。

### 核心改动

- **`providers.try_chain(method, dim, market, *args)`** · 一行失败转移助手，按 \`UZI_PROVIDERS_<DIM>\` env 排序，方法未实现自动跳过
- **`_kline_a_share_chain` 第 7 层兜底** · 前 6 层（akshare-em / sina / baostock / 东财 / 新浪 / 腾讯 HTTP）全挂时调 \`try_chain\` 让 tushare/efinance 救场
- **`tushare.fetch_kline_a`（新增）** · \`pro.daily + adj_factor\` 前复权；之前 tushare K 线完全缺
- **Provider 健康 CLI** · \`python -m lib.providers\` 表格化状态 + 启用建议；\`chain A kline\` 看优先级链

## Test plan

- [x] 88 passing（原 80 + 8 新）· \`pytest tests/\`
- [x] \`python -m lib.providers\` 跑出正确表格
- [x] \`UZI_PROVIDERS_KLINE=baostock,akshare python -m lib.providers chain A kline\` 验证 env 覆盖
- [x] try_chain 3 种路径：成功拿到 (data, src) / 全失败抛 ProviderError / 方法未实现自动跳过
- [x] tushare provider 新增 \`fetch_kline_a\` 方法存在性断言

🤖 Generated with [Claude Code](https://claude.com/claude-code)