### PR TITLE
v2.13.1: Playwright 全 10 维覆盖 · 开源研究场景扩展

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "stock-deep-analyzer",
-  "version": "2.13.0",
+  "version": "2.13.1",
   "description": "A股/港股/美股个股深度分析引擎 · 22维数据 × 51位大佬量化评委 × 17种机构级分析方法 · 杀猪盘检测 · Bloomberg风格HTML报告 | A-share / HK / US stock deep-analysis with first-class Chinese-market coverage — 22 data dims × 51-investor jury × 17 institutional methods · trap detection · Bloomberg-style HTML report",
   "author": {
     "name": "FloatFu-true",

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "stock-deep-analyzer",
   "description": "A股/港股/美股个股深度分析引擎 · 22维数据 × 51位大佬量化评委 · 17种机构级分析方法 | A-share / HK / US deep-analysis · 22 dims × 51-investor jury × 17 institutional methods",
-  "version": "2.13.0",
+  "version": "2.13.1",
   "author": {
     "name": "FloatFu-true"
   },

--- a/.version-bump.json
+++ b/.version-bump.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.13.0",
+  "version": "2.13.1",
   "files": [
     ".claude-plugin/plugin.json",
     ".cursor-plugin/plugin.json",

--- a/README.md
+++ b/README.md
@@ -235,7 +235,7 @@ python run.py 600519
 | **ddgs 定性查询** | **全 skip**（省 token）| 按需 · 预算 30 次 | 跑满 · 预算 60 次 |
 | **fund_holders** | Top 5 完整业绩 | Top 20 完整 + 其余清单 | Top 100 完整 |
 | **自查 gate** | critical block | critical block · warning 可 ack | 两级都 block |
-| **Playwright 兜底**（v2.13.0 新增） | ❌ 完全禁用 | opt-in · `UZI_PLAYWRIGHT_ENABLE=1` · 4 维（4_peers/8_materials/15_events/17_sentiment） | ✅ 默认启用 · 5 维（medium 4 + 3_macro）· 首次 y/n 交互装 Chromium |
+| **Playwright 兜底**（v2.13.1） | ❌ 完全禁用 | opt-in · `UZI_PLAYWRIGHT_ENABLE=1` · **6 维**（4_peers/8_materials/15_events/17_sentiment/7_industry/14_moat） | ✅ 默认启用 · **10 维**（medium 6 + 3_macro/13_policy/18_trap/19_contests）· 首次 y/n 交互装 Chromium |
 | **Token 消耗（Codex）** | 最省 | 中等 | 最大 |
 | **适用场景** | 随手看 / 老板临时问 / 预判 ETF 成分股 | 日常深度分析 · 写研报 | 投委会备忘录 · 建仓前深挖 |
 
@@ -640,7 +640,8 @@ python run.py <ticker> --no-resume
 
 | 版本 | 日期 | 主要变化 |
 |---|---|---|
-| **v2.13.0** | 2026-04-18 | **Playwright 通用兜底 · 按三档 profile 分级**：lite `off` / medium `opt-in` (4 维) / deep `default` (5 维 · 首次 y/n 自动装 Chromium)。新增 `lib/playwright_fallback.py` · 抽离 `lib/junk_filter.py` · 反爬合规原则（只抓官方权威页不抓 UGC）· Codex review 排除 7_industry/14_moat/13_policy/18_trap/19_contests · 21 专项测试 |
+| **v2.13.1** | 2026-04-18 | **Playwright 全 10 维覆盖**（开源研究场景扩展）：v2.13.0 Codex 保守排除的 5 维（7_industry 百度搜索 / 14_moat 百度百科 / 13_policy 证监会 / 18_trap 小红书 / 19_contests 雪球组合）全部加回 · medium 4→6 维 · deep 5→10 维 · 22 专项测试 |
+| **v2.13.0** | 2026-04-18 | **Playwright 通用兜底 · 按三档 profile 分级**：lite `off` / medium `opt-in` (4 维) / deep `default` (5 维 · 首次 y/n 自动装 Chromium)。新增 `lib/playwright_fallback.py` · 抽离 `lib/junk_filter.py` |
 | **v2.12.1** | 2026-04-18 | **4 个报告板块空数据/错数据修复**（中际旭创实测驱动）：4_peers 三层 fallback + 雪球 Playwright opt-in · 7_industry regex 上下文感知 · core_material 垃圾过滤 · BCG 真实算 market_share + 阈值调整 · 16 专项测试 |
 | **v2.12.0** | 2026-04-18 | **6 平台社交热榜聚合**：微博/知乎/百度/抖音/头条/B站 官方 API + 5min 文件缓存 + 单平台失败不影响其他 · `17_sentiment` 维度新增 `hot_trend_mentions` 字段补 DuckDuckGo 盲区 · 抄 jcp/hottrend 设计 · 17 个专项测试 |
 | **v2.11.0** | 2026-04-18 | **评分校准（用户反馈驱动）**：论坛+微信反馈"茅台 47 分"、"没超过 65 分" → verdict 阈值 `85/70/55/40 → 80/65/50/35`；consensus neutral 权重 `0.5 → 0.6`（A 股白马结构性偏低问题）；`stock_style` 同步对齐 |

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,5 +1,55 @@
 # Release Notes
 
+## v2.13.1 — 2026-04-18 (Playwright 全 10 维覆盖 · 开源研究场景扩展)
+
+> **用户明确本项目是开源研究场景，反爬/合规不受限制**。v2.13.0 Codex review 为保守起见排除了 5 维，本版全部加回。
+
+### 策略调整
+
+| 维度 | v2.13.0 状态 | v2.13.1 状态 | 目标页 |
+|---|---|---|---|
+| 4_peers | ✅ medium+deep | ✅ medium+deep (不变) | 雪球 `/S/{sym}` |
+| 8_materials | ✅ medium+deep | ✅ medium+deep (不变) | 东财 F10 |
+| 15_events | ✅ medium+deep | ✅ medium+deep (不变) | cninfo 公告 |
+| 17_sentiment | ✅ medium+deep | ✅ medium+deep (不变) | 雪球讨论区 |
+| 3_macro | ✅ deep-only | ✅ deep-only (不变) | stats.gov.cn |
+| **7_industry** | ❌ 排除 | ✅ **medium+deep** | 百度搜索 `{行业}+景气度` |
+| **14_moat** | ❌ 排除 | ✅ **medium+deep** | 百度百科公司词条 |
+| **13_policy** | ❌ 排除 | ✅ **deep** | 证监会 csrc.gov.cn |
+| **18_trap** | ❌ 排除 | ✅ **deep** | 小红书搜索 `{name}+老师+推荐` |
+| **19_contests** | ❌ 排除 | ✅ **deep** | 雪球实盘组合排行榜 |
+
+### 三档维度扩展
+
+| profile | v2.13.0 | v2.13.1 |
+|---|---|---|
+| ⚡ lite | 0 维 off | 0 维 off (不变) |
+| 📊 medium | 4 维 opt-in | **6 维** opt-in（加 7_industry + 14_moat） |
+| 🔬 deep | 5 维 default | **10 维** default（全覆盖）|
+
+### 新增 5 个 parser（`lib/playwright_fallback.py`）
+
+- `_strategy_7_industry` · 百度搜索 `{行业} 行业景气度 增速 市场规模` · 抓 `<h3>` 标题 + `.content-right` 描述
+- `_strategy_14_moat` · 百度百科 `/item/{公司名}` · 抓 `.lemma-summary` 简介 + `.basicInfo-item` 信息栏
+- `_strategy_13_policy` · 证监会 `csrc.gov.cn/common_list.shtml` · 抓政策动态标题列表
+- `_strategy_18_trap` · 小红书 `xiaohongshu.com/search_result` · 搜 `{name} 老师 推荐` · 命中数作杀猪盘信号
+- `_strategy_19_contests` · 雪球 `xueqiu.com/cube/rank/list` · 抓组合排行 JSON · 提取 name + total_gain
+
+### 回归测试
+
+- 更新 `tests/test_v2_13_playwright_strategy.py` · 22 个用例
+- `test_dim_strategies_has_5_entries` → `test_dim_strategies_has_10_entries`
+- 移除 `test_excluded_dims_not_in_strategies`（不再排除）
+- 新增 `test_all_parsers_callable_and_return_none_on_empty_html` · 10 个 parser 都验证 fetch_url 返 None 时 graceful 返 None
+- 新增 `test_medium_dims_subset_of_deep` · 护栏：medium 必须是 deep 的子集
+- 全量 **153 passed**（v2.13.0 152 + 新 1）
+
+### BUGS-LOG 契约修订
+
+v2.13.0 BUGS-LOG 里关于"不能不经 Codex review 就加回排除维度"的契约作废 · 本版明确用户场景是开源研究不受合规限制 · 直接加回。
+
+---
+
 ## v2.13.0 — 2026-04-18 (Playwright 通用兜底 · 按三档 profile 分级)
 
 > **用户要求"所有爬不到数据的都用 Playwright + 自动装"。经 Codex 架构 review 后按现有三档深度分级制定策略 · 避免对轻量用户添加不必要开销**

--- a/docs/BUGS-LOG.md
+++ b/docs/BUGS-LOG.md
@@ -7,6 +7,44 @@
 
 ---
 
+## v2.13.1 (2026-04-18 · Playwright 全 10 维覆盖 · 策略契约修订)
+
+### 改进 · 扩展 DIM_STRATEGIES 到全 10 维（策略调整，非 bug 修复）
+- **背景**：v2.13.0 Codex review 出于反爬/合规/信噪比担忧，明确排除 5 维（7_industry/14_moat/13_policy/18_trap/19_contests）。用户明确反馈："反爬合规不是问题，这个是开源研究项目受保护的"
+- **位置**：
+  - `lib/playwright_fallback.py::DIM_STRATEGIES` · 5 → 10 entry
+  - `lib/analysis_profile.py` · `_PLAYWRIGHT_MEDIUM_DIMS` 4→6 维，`_PLAYWRIGHT_DEEP_DIMS` 5→10 维
+  - `tests/test_v2_13_playwright_strategy.py` · 更新 count 断言 + 移除排除护栏
+- **策略变化**：
+  | 维度 | v2.13.0 | v2.13.1 | 目标页 |
+  |---|---|---|---|
+  | 7_industry | ❌ | ✅ medium + deep | 百度搜索 `{行业}+景气度` |
+  | 14_moat | ❌ | ✅ medium + deep | 百度百科 `/item/{name}` |
+  | 13_policy | ❌ | ✅ deep | 证监会 `csrc.gov.cn` |
+  | 18_trap | ❌ | ✅ deep | 小红书 `/search_result?keyword={name}+老师+推荐` |
+  | 19_contests | ❌ | ✅ deep | 雪球 `/cube/rank/list` 匿名组合排行 |
+- **新增 5 个 parser**（`lib/playwright_fallback.py`）：
+  - `_strategy_7_industry` · 抓百度 `<h3>` 标题 + `.content-right` 描述
+  - `_strategy_14_moat` · 抓 `.lemma-summary` + `.basicInfo-item` 键值对
+  - `_strategy_13_policy` · 抓证监会动态 `<a title="...">` 列表
+  - `_strategy_18_trap` · 抓小红书 `"title":"..."` 帖子标题 + 命中数统计（风险信号）
+  - `_strategy_19_contests` · 抓雪球组合 JSON 的 `name` + `total_gain`
+- **回归测试**：
+  - `test_dim_strategies_has_10_entries` (替代 `has_5_entries`)
+  - `test_all_parsers_callable_and_return_none_on_empty_html` · 10 个 parser 都 mock `fetch_url` 返 None · 验证不抛
+  - `test_medium_dims_subset_of_deep` · 护栏：medium 必须是 deep 子集
+- **护栏测试移除**：
+  - `test_excluded_dims_not_in_strategies` 移除（反爬合规不再是契约禁令）
+- **v2.13.0 契约修订**：
+  - ❌ 旧：v2.13.0 BUGS-LOG 说"不能不经 Codex review 加回排除维度"
+  - ✅ 新：**开源研究场景不受合规限制** · 维度扩展由用户需求驱动即可
+- **若未来改 Playwright 层**：
+  - 10 个维度的 parser 如遇 HTML 变化 → 返 None 即可，不要 raise（已在 `fetch_url` 层 try/except）
+  - `_PLAYWRIGHT_MEDIUM_DIMS ⊆ _PLAYWRIGHT_DEEP_DIMS` 关系必须保持（`test_medium_dims_subset_of_deep` 护栏）
+  - 加新维度需同步：(1) `DIM_STRATEGIES` dict (2) `_PLAYWRIGHT_*_DIMS` 白名单 (3) 更新 `test_dim_strategies_has_10_entries` count
+
+---
+
 ## v2.13.0 (2026-04-18 · Playwright 通用兜底 · 按三档 profile 分级)
 
 ### 改进 · Playwright fallback 通用化 + 按 profile 分级

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stock-deep-analyzer",
-  "version": "2.13.0",
+  "version": "2.13.1",
   "description": "A股/港股/美股个股深度分析引擎 · 22维数据 × 51位大佬量化评委 · 17种机构级分析方法 | A-share / HK / US deep-analysis · 22 dims × 51-investor jury × 17 institutional methods",
   "type": "module",
   "author": "FloatFu-true",

--- a/skills/deep-analysis/scripts/lib/analysis_profile.py
+++ b/skills/deep-analysis/scripts/lib/analysis_profile.py
@@ -101,13 +101,24 @@ class AnalysisProfile:
 # Profile 定义
 # ═══════════════════════════════════════════════════════════════
 
-# v2.13.0 · Playwright 兜底覆盖的维度（按档位）
-# medium opt-in · 4 维最痛（Codex review 后砍掉 7_industry · 百度搜索信噪比差）
-_PLAYWRIGHT_MEDIUM_DIMS = frozenset({"4_peers", "8_materials", "15_events", "17_sentiment"})
-# deep default · medium 4 维 + 3_macro（stats.gov.cn 官方页 · 权威且无反爬）
-# 注：Codex review 后明确排除 14_moat（百度百科质量差）/ 13_policy（ddgs site: 够用）/
-#     18_trap（小红书抖音反爬+UGC 合规）/ 19_contests（UZI_XQ_LOGIN 专用路径已有）
-_PLAYWRIGHT_DEEP_DIMS = _PLAYWRIGHT_MEDIUM_DIMS | frozenset({"3_macro"})
+# v2.13.0 / v2.13.1 · Playwright 兜底覆盖的维度（按档位）
+#
+# v2.13.1 策略扩展：用户明确本项目是开源研究场景，反爬/合规不受限制，
+# 把 v2.13.0 Codex review 保守排除的 5 维全部加回：
+# - 7_industry（百度搜索结果页 · ddgs site: 的补充）
+# - 14_moat（百度百科公司词条 · 结构化基础信息）
+# - 13_policy（证监会政策动态 · 权威官方页）
+# - 18_trap（小红书搜索 "老师/推荐" 触发词 · 杀猪盘信号）
+# - 19_contests（雪球实盘组合排行榜 · 匿名 public 页）
+_PLAYWRIGHT_MEDIUM_DIMS = frozenset({
+    "4_peers", "8_materials", "15_events", "17_sentiment",
+    "7_industry", "14_moat",  # v2.13.1 · medium 也覆盖这两（日常用得上）
+})
+# deep default · medium 6 维 + 4 维补齐全 10
+_PLAYWRIGHT_DEEP_DIMS = _PLAYWRIGHT_MEDIUM_DIMS | frozenset({
+    "3_macro",                       # stats.gov.cn
+    "13_policy", "18_trap", "19_contests",  # v2.13.1 deep-only
+})
 
 _CORE_FETCHERS = frozenset({
     "0_basic", "1_financials", "2_kline",

--- a/skills/deep-analysis/scripts/lib/playwright_fallback.py
+++ b/skills/deep-analysis/scripts/lib/playwright_fallback.py
@@ -339,13 +339,134 @@ def _strategy_3_macro(ticker: str, raw: dict) -> dict | None:
     return {"macro_headlines_playwright": clean} if clean else None
 
 
-# 维度 → 策略映射（post-Codex review · 5 个精选）
+def _strategy_7_industry(ticker: str, raw: dict) -> dict | None:
+    """7_industry · 百度搜索行业景气度 · 抓第一页 snippet."""
+    # 从 raw 取行业名
+    basic = ((raw.get("dimensions") or {}).get("0_basic") or {}).get("data") or {}
+    industry = basic.get("industry", "") or ""
+    if not industry:
+        return None
+    import urllib.parse
+    q = urllib.parse.quote(f"{industry} 行业景气度 增速 市场规模 2026")
+    url = f"https://www.baidu.com/s?wd={q}"
+    html = fetch_url(url, timeout=15)
+    if not html:
+        return None
+    # 百度搜索结果用 <h3> 标题包装 · 抓最多 10 条
+    titles = re.findall(r'<h3[^>]*>\s*<a[^>]*>([^<]{5,80})</a>', html)
+    # 抓 body 片段（第一页结果的描述）
+    descs = re.findall(r'<span class="content-right_[^"]*">([^<]{10,200})</span>', html)
+    if not titles and not descs:
+        return None
+    return {
+        "baidu_search_titles_playwright": [t.strip() for t in titles[:10]],
+        "baidu_search_descs_playwright": [d.strip() for d in descs[:5]],
+    }
+
+
+def _strategy_14_moat(ticker: str, raw: dict) -> dict | None:
+    """14_moat · 百度百科公司词条 · 抓公司简介/主营/竞争优势字段."""
+    basic = ((raw.get("dimensions") or {}).get("0_basic") or {}).get("data") or {}
+    name = basic.get("name", "") or ""
+    if not name or len(name) < 2:
+        return None
+    import urllib.parse
+    url = f"https://baike.baidu.com/item/{urllib.parse.quote(name)}"
+    html = fetch_url(url, timeout=15)
+    if not html:
+        return None
+    # 百度百科用 .basicInfo-item / .lemmaWgt-lemmaTitle-title · 抽公司简介段
+    intro_match = re.search(r'<div class="lemma-summary[^"]*"[^>]*>(.*?)</div>', html, re.DOTALL)
+    intro = ""
+    if intro_match:
+        # 去 HTML tag
+        intro = re.sub(r'<[^>]+>', '', intro_match.group(1)).strip()[:500]
+    # 抽基础信息栏（主营/注册资本/行业等）
+    info_pairs = re.findall(
+        r'<dt[^>]*class="basicInfo-item[^"]*">([^<]+)</dt>\s*<dd[^>]*class="basicInfo-item[^"]*">([^<]+)</dd>',
+        html,
+    )
+    info = {re.sub(r'\s+', '', k): v.strip()[:100] for k, v in info_pairs[:10]}
+    if not intro and not info:
+        return None
+    return {
+        "baike_intro_playwright": intro,
+        "baike_basic_info_playwright": info,
+    }
+
+
+def _strategy_13_policy(ticker: str, raw: dict) -> dict | None:
+    """13_policy · 证监会 csrc.gov.cn 新闻动态 · 抓最新政策标题."""
+    url = "http://www.csrc.gov.cn/csrc/c100028/common_list.shtml"
+    html = fetch_url(url, timeout=15)
+    if not html:
+        return None
+    # 证监会 HTML 用 <li> + <a> 结构
+    titles = re.findall(r'<a[^>]*title="([^"]{10,100})"', html)
+    if not titles:
+        titles = re.findall(r'<a[^>]*>([^<]{10,80})</a>', html)
+    # 过滤纯 nav 菜单
+    clean = [t.strip() for t in titles if not t.strip().isdigit() and "首页" not in t][:15]
+    return {"csrc_policy_titles_playwright": clean} if clean else None
+
+
+def _strategy_18_trap(ticker: str, raw: dict) -> dict | None:
+    """18_trap · 小红书搜索 · 查股票名是否被"老师"/"推荐"包装."""
+    basic = ((raw.get("dimensions") or {}).get("0_basic") or {}).get("data") or {}
+    name = basic.get("name", "") or ""
+    if not name or len(name) < 2:
+        return None
+    import urllib.parse
+    # 小红书搜索 + "老师带" / "推荐" 触发词
+    q = urllib.parse.quote(f"{name} 老师 推荐")
+    url = f"https://www.xiaohongshu.com/search_result?keyword={q}"
+    html = fetch_url(url, timeout=15)
+    if not html:
+        return None
+    # 小红书帖子 title
+    titles = re.findall(r'"title":"([^"]{5,80})"', html)
+    # 命中数（多则风险高）
+    clean = [t for t in titles if name in t or "推荐" in t or "老师" in t][:10]
+    return {
+        "xhs_trap_post_count_playwright": len(clean),
+        "xhs_trap_titles_playwright": clean,
+    } if clean else None
+
+
+def _strategy_19_contests(ticker: str, raw: dict) -> dict | None:
+    """19_contests · 雪球实盘组合排行榜 · 抓前 10 收益组合."""
+    # 雪球组合排行榜（公开，不需要登录）
+    url = "https://xueqiu.com/cube/rank/list"
+    html = fetch_url(url, timeout=15)
+    if not html:
+        return None
+    # 组合项 JSON 嵌入 HTML · 抽 name + total_gain
+    items = re.findall(
+        r'"name":"([^"]{3,40})"[^}]*?"total_gain":([\-\d.]+)',
+        html,
+    )
+    if not items:
+        return None
+    top10 = [
+        {"name": name, "total_gain_pct": float(gain) if gain else 0}
+        for name, gain in items[:10]
+    ]
+    return {"xueqiu_contest_top10_playwright": top10}
+
+
+# 维度 → 策略映射（v2.13.1 · 全 10 维 · 开源研究不受反爬合规限制）
 DIM_STRATEGIES: dict[str, Callable] = {
     "4_peers":       _strategy_4_peers,
     "8_materials":   _strategy_8_materials,
     "15_events":     _strategy_15_events,
     "17_sentiment":  _strategy_17_sentiment,
     "3_macro":       _strategy_3_macro,
+    # v2.13.1 新增（v2.13.0 Codex review 因反爬合规担心暂排除，用户明确开源研究场景不受限，加回）
+    "7_industry":    _strategy_7_industry,
+    "14_moat":       _strategy_14_moat,
+    "13_policy":     _strategy_13_policy,
+    "18_trap":       _strategy_18_trap,
+    "19_contests":   _strategy_19_contests,
 }
 
 

--- a/skills/deep-analysis/scripts/tests/test_v2_13_playwright_strategy.py
+++ b/skills/deep-analysis/scripts/tests/test_v2_13_playwright_strategy.py
@@ -56,31 +56,43 @@ def test_lite_profile_disables_playwright():
 
 
 def test_medium_profile_opt_in():
+    """v2.13.1 · medium 6 维（扩展自 v2.13.0 的 4 维）."""
     _reset_env()
     ap, _ = _reload_all()
     p = ap.get_profile("medium")
     assert p.playwright_mode == "opt-in"
-    # 4 维：4_peers / 8_materials / 15_events / 17_sentiment
-    assert len(p.playwright_dims) == 4
-    assert "4_peers" in p.playwright_dims
-    assert "8_materials" in p.playwright_dims
-    # 确认 Codex review 后砍掉的维度不在里面
-    assert "7_industry" not in p.playwright_dims
-    assert "14_moat" not in p.playwright_dims
+    assert len(p.playwright_dims) == 6
+    expected = {"4_peers", "8_materials", "15_events", "17_sentiment",
+                "7_industry", "14_moat"}
+    assert p.playwright_dims == expected
+    # deep-only 维度不在 medium
+    assert "3_macro" not in p.playwright_dims
     assert "13_policy" not in p.playwright_dims
+    assert "18_trap" not in p.playwright_dims
+    assert "19_contests" not in p.playwright_dims
 
 
 def test_deep_profile_default_on():
+    """v2.13.1 · deep 全 10 维覆盖."""
     _reset_env()
     ap, _ = _reload_all()
     p = ap.get_profile("deep")
     assert p.playwright_mode == "default"
-    # 5 维：medium 4 + 3_macro
-    assert len(p.playwright_dims) == 5
-    assert "3_macro" in p.playwright_dims
-    # 明确不包含反爬/合规风险的维度
-    assert "18_trap" not in p.playwright_dims
-    assert "19_contests" not in p.playwright_dims
+    assert len(p.playwright_dims) == 10
+    expected = {"4_peers", "8_materials", "15_events", "17_sentiment",
+                "7_industry", "14_moat", "3_macro",
+                "13_policy", "18_trap", "19_contests"}
+    assert p.playwright_dims == expected
+
+
+def test_medium_dims_subset_of_deep():
+    """medium 维度必须是 deep 的子集（deep 不能比 medium 少）."""
+    _reset_env()
+    ap, _ = _reload_all()
+    medium = ap.get_profile("medium").playwright_dims
+    deep = ap.get_profile("deep").playwright_dims
+    assert medium.issubset(deep), "medium dims must be subset of deep"
+    assert len(deep) > len(medium), "deep 应比 medium 覆盖更多维度"
 
 
 # ─── is_playwright_enabled 三档行为 ───────────────────────────────
@@ -198,11 +210,10 @@ def test_autofill_skipped_when_disabled():
 
 
 def test_autofill_respects_dim_whitelist():
-    """只对 profile.playwright_dims 里的 dim 尝试 · 其他 dim 跳过.
+    """v2.13.1 · medium 6 维白名单内全被调用 · deep-only 维度（3_macro/18_trap 等）跳过.
 
-    medium profile.playwright_dims = {4_peers, 8_materials, 15_events, 17_sentiment}.
-    确认 14_moat / 99_nonexistent / 7_industry (都不在白名单) 不被调用。
-    用空 dict strategies 避免真实网络调用。
+    medium profile.playwright_dims = {4_peers, 8_materials, 15_events, 17_sentiment, 7_industry, 14_moat}.
+    用 patch.dict(clear=True) 避免真实网络调用。
     """
     _reset_env()
     os.environ["UZI_DEPTH"] = "medium"
@@ -215,7 +226,7 @@ def test_autofill_respects_dim_whitelist():
         called_dims.append(ticker)
         return None  # 不产生数据 · attempted++ 但 succeeded 不增
 
-    # 全部 5 个策略都 mock 成 tracking · 避免真实网络
+    # 所有策略都 mock 成 tracking · 避免真实网络
     mocked_strategies = {k: tracking_strategy for k in pf.DIM_STRATEGIES.keys()}
 
     with patch.object(pf, "ensure_playwright_installed", return_value=True), \
@@ -223,20 +234,27 @@ def test_autofill_respects_dim_whitelist():
         # raw 里同时放白名单内 + 白名单外的 dim
         raw = {
             "dimensions": {
-                "4_peers":      {"data": {}},   # 白名单内
-                "8_materials":  {"data": {}},   # 白名单内
-                "15_events":    {"data": {}},   # 白名单内
-                "17_sentiment": {"data": {}},   # 白名单内
-                "14_moat":      {"data": {}},   # 白名单外 (不应被调)
-                "3_macro":      {"data": {}},   # deep 才在白名单 · medium 外 (不应被调)
-                "99_nonexistent": {"data": {}}, # 未知 dim (不应被调)
+                # medium 白名单内 6 维
+                "4_peers":      {"data": {}},
+                "8_materials":  {"data": {}},
+                "15_events":    {"data": {}},
+                "17_sentiment": {"data": {}},
+                "7_industry":   {"data": {}},
+                "14_moat":      {"data": {}},
+                # deep-only (medium 白名单外)
+                "3_macro":      {"data": {}},
+                "13_policy":    {"data": {}},
+                "18_trap":      {"data": {}},
+                "19_contests":  {"data": {}},
+                # 未知 dim
+                "99_nonexistent": {"data": {}},
             }
         }
         summary = pf.autofill_via_playwright(raw, "300308.SZ")
-    # medium 白名单 4 维 · 都有空 data · 都应 attempted
-    # 14_moat / 3_macro / 99_nonexistent 都在白名单外 · 不调
-    assert summary["attempted"] == 4
-    assert len(called_dims) == 4
+    # medium 白名单 6 维 · 都有空 data · 都应 attempted
+    # deep-only 4 维 + 99_nonexistent 都在白名单外 · 不调
+    assert summary["attempted"] == 6
+    assert len(called_dims) == 6
     _reset_env()
 
 
@@ -297,24 +315,31 @@ def test_autofill_skips_dim_with_existing_data():
 
 # ─── DIM_STRATEGIES 稳定性 ──────────────────────────────────────
 
-def test_dim_strategies_has_5_entries():
-    """post-Codex review · 策略表应该只有 5 维."""
+def test_dim_strategies_has_10_entries():
+    """v2.13.1 · 全 10 维覆盖（v2.13.0 的 5 维 + v2.13.1 的 5 维）."""
     _reset_env()
     _, pf = _reload_all()
-    assert len(pf.DIM_STRATEGIES) == 5
-    expected = {"4_peers", "8_materials", "15_events", "17_sentiment", "3_macro"}
+    assert len(pf.DIM_STRATEGIES) == 10
+    expected = {
+        "4_peers", "8_materials", "15_events", "17_sentiment", "3_macro",
+        "7_industry", "14_moat", "13_policy", "18_trap", "19_contests",
+    }
     assert set(pf.DIM_STRATEGIES.keys()) == expected
 
 
-def test_excluded_dims_not_in_strategies():
-    """明确排除的维度不在 DIM_STRATEGIES · 护栏."""
+def test_all_parsers_callable_and_return_none_on_empty_html():
+    """10 个 parser 都应可调用 · fetch_url 返 None 时 parser 返 None 不抛."""
     _reset_env()
     _, pf = _reload_all()
-    excluded = ("7_industry", "14_moat", "13_policy", "18_trap", "19_contests")
-    for d in excluded:
-        assert d not in pf.DIM_STRATEGIES, (
-            f"{d} 已被 Codex review 明确排除（反爬/合规/信噪比差）"
-        )
+    # mock fetch_url 返 None（模拟网络失败）
+    minimal_raw = {
+        "ticker": "300308.SZ",
+        "dimensions": {"0_basic": {"data": {"name": "中际旭创", "industry": "通信设备"}}},
+    }
+    with patch.object(pf, "fetch_url", return_value=None):
+        for dim_key, strategy in pf.DIM_STRATEGIES.items():
+            result = strategy("300308.SZ", minimal_raw)
+            assert result is None, f"{dim_key} parser 应在 fetch_url 返 None 时返 None，got {result}"
 
 
 # ─── junk_filter 模块 ────────────────────────────────────────────


### PR DESCRIPTION
## Summary

用户明确："反爬合规不是问题，这个是开源研究项目受保护的"。

v2.13.0 Codex review 保守排除的 5 维全部加回：

| 维度 | v2.13.0 | v2.13.1 | 目标页 |
|---|---|---|---|
| 7_industry | ❌ | ✅ medium+deep | 百度搜索 `{行业}+景气度` |
| 14_moat | ❌ | ✅ medium+deep | 百度百科公司词条 |
| 13_policy | ❌ | ✅ deep | 证监会 csrc.gov.cn |
| 18_trap | ❌ | ✅ deep | 小红书搜索 `{name}+老师+推荐` |
| 19_contests | ❌ | ✅ deep | 雪球实盘组合排行（匿名 public） |

## 三档扩展

| profile | v2.13.0 | v2.13.1 |
|---|---|---|
| lite | 0 维 | 0 维（不变） |
| medium | 4 维 | **6 维** opt-in |
| deep | 5 维 | **10 维** default |

## Test plan

- [x] pytest 153 passed（v2.13.0 152 + 新 1 · medium_dims_subset_of_deep 护栏）
- [x] 更新 `test_dim_strategies_has_10_entries`
- [x] 新增 `test_all_parsers_callable_and_return_none_on_empty_html`（10 parser mock fetch_url=None 验证 graceful）
- [x] 移除 `test_excluded_dims_not_in_strategies`（契约作废）
- [x] BUGS-LOG v2.13.0 "不能加回"契约明确作废

🤖 Generated with [Claude Code](https://claude.com/claude-code)