### PR TITLE
v2.13.3: 51 评委规则全员历史立场还原 · 5 处 bug 修复

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "stock-deep-analyzer",
-  "version": "2.13.2",
+  "version": "2.13.3",
   "description": "A股/港股/美股个股深度分析引擎 · 22维数据 × 51位大佬量化评委 × 17种机构级分析方法 · 杀猪盘检测 · Bloomberg风格HTML报告 | A-share / HK / US stock deep-analysis with first-class Chinese-market coverage — 22 data dims × 51-investor jury × 17 institutional methods · trap detection · Bloomberg-style HTML report",
   "author": {
     "name": "FloatFu-true",

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "stock-deep-analyzer",
   "description": "A股/港股/美股个股深度分析引擎 · 22维数据 × 51位大佬量化评委 · 17种机构级分析方法 | A-share / HK / US deep-analysis · 22 dims × 51-investor jury × 17 institutional methods",
-  "version": "2.13.2",
+  "version": "2.13.3",
   "author": {
     "name": "FloatFu-true"
   },

--- a/.version-bump.json
+++ b/.version-bump.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.13.2",
+  "version": "2.13.3",
   "files": [
     ".claude-plugin/plugin.json",
     ".cursor-plugin/plugin.json",

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,5 +1,85 @@
 # Release Notes
 
+## v2.13.3 — 2026-04-19 (51 评委规则全员历史立场还原)
+
+> **用户反馈**："林奇是不是有点激进？他历史上的持仓和操作，麻烦你核对一下" · 中际旭创 300308.SZ 实测发现 **19 人给 100 分** 严重不合理，多位评委立场与历史不符
+
+### 根因诊断
+
+从 300308 面板扫描 v2.13.2 分数分布：
+- 19 人给 100 分（含 13 位游资 + 林奇 + 索罗斯 + 段永平 + 张坤 + 邓晓峰）
+- 木头姐 13 分看空（CPO 本是她核心赛道，被判 0% 行业增速）
+- F 组游资"市值 9456 亿 > 150 亿 = 看多 100" / "超 80 亿 = 看空"（反向 bug）
+
+### 5 处规则修复
+
+**Fix 1 · F 组游资射程**
+- `seat_db.is_in_range` 加隐式 500 亿大市值上限（章盟主 allowlist 除外，历史做过茅台大盘）
+- `investor_evaluator._is_youzi_out_of_range` 前置检查 · 超射程直接 skip 不打分
+- `_youzi_base_rules` 移除 min_mcap/max_mcap 作为 Rule（避免"市值超标"反向打分）
+- **300308 效果**：F 组 22/23 人正确 skip（原 13 人错打高分）
+
+**Fix 2 · 索罗斯反身性方向**
+- 原 bug：`abs(upside_to_target) > 10` · 目标价 -63% 也被判"反身性差 = 看多 100"
+- 修：拆两条规则
+  - `sentiment_long_reflex` · 只在 upside > +10% 时 pass（做多反身性）
+  - `sentiment_short_reflex_penalty` · upside < -15% 扣分（识别市场狂热）
+- **300308 效果**：索罗斯 100 → 42 neutral · "无做多反身性空间"
+
+**Fix 3 · 林奇 PEG 严格化 + PE 40 红线**
+- 依据 *One Up on Wall Street (1989)* / *Beating the Street (1993)*：
+  - PEG ≤ 1 理想（Taco Bell 0.6 / Hanes 0.2 / Fannie Mae 0.6 均低于 1）
+  - PE > 40 "like buying a Rolls Royce" · 林奇警戒线
+  - Fast grower sweet spot 20-50%
+- 原版单条 `peg_reasonable PEG < 1.5` 过松 · 拆 6 条：
+  - `peg_ideal` PEG < 1（5 分）
+  - `peg_acceptable` PEG 1-1.5（3 分）
+  - `pe_not_rolls_royce` PE < 40（3 分）← 新增
+  - `fast_grower_zone` 20-50%（3 分）
+  - `understandable` + `research_support`（2+2 分）
+- **300308 效果**：林奇 100 → 38 neutral · "PE 63 · Rolls Royce 不是必要品"
+
+**Fix 4 · 木头姐颠覆性判定**
+- 两处 bug：
+  - 字段名错：读 `industry_growth_pct` · 实际 stock_features 设的是 `industry_growth` · 中际旭创读成 0 判"增长太慢"
+  - 白名单缺 CPO/光模块/算力/数据中心/HBM · AI 基建本是 ARK 核心赛道
+- 修：字段兼容读 · 白名单加 AI 算力相关 12 个关键词
+- **300308 效果**：木头姐 13 bearish → 80 bullish · "行业增速 40% — S 曲线拐点"
+
+**Fix 5 · 中国价投派 PE 红线**
+- 段永平：历史买苹果 PE 18 / 茅台 PE 30 / 腾讯 PE 25 · 对 PE 50+ 永远"贵了"
+- 张坤：重仓茅台/五粮液/腾讯 PE 15-35 区间
+- 邓晓峰：偏左侧风格 · 白酒/地产/银行/周期股 PE 都偏低
+- 各加 1 条 PE 红线规则（段 PE<40 · 张 PE<40 · 邓 PE<35）
+- **300308 效果**：段永平 100→84 · 张坤 100→78 · 邓晓峰 100→76（仍看多但不再狂热）
+
+### 评分分布对照（300308.SZ）
+
+| 桶 | v2.13.2 | v2.13.3 |
+|---|---|---|
+| 100 分 | **19 人** | **5 人** |
+| 70-99 | 2 | 12 |
+| 40-69 | 7（neutral/bearish） | 7 |
+| < 40 | 9（含 4 游资 misjudged） | 4 |
+| skip | 1 | **23**（F 组 22 + 索普） |
+| consensus | 78 | **81.4**（分母 28，质量提升） |
+
+### 回归测试
+
+- 新增 `tests/test_v2_13_3_investor_rules.py` · **15 个用例**
+  - Fix 1 · 4 游资射程 scenarios
+  - Fix 2 · 索罗斯 3 方向（看多/看空/neutral）
+  - Fix 3 · 林奇 3 PEG 区间
+  - Fix 4 · 木头姐 CPO 识别 + 字段兼容
+  - Fix 5 · 段永平/张坤 PE 红线 + 护栏
+- 全量 **173 passed**（v2.13.2 158 + 新 15）
+
+### 升级
+
+`git pull origin main` · 老 cache 下次 stage1 自动用新规则重算 panel.json · 无需 --no-resume（v2.9 的 panel 不 cache · 每次都重算）
+
+---
+
 ## v2.13.2 — 2026-04-19 (Playwright 触发逻辑升级 · 数据质量感知 + FORCE flag)
 
 > **用户反馈**："有很多网站爬不到内容，也没有拉起 Playwright" · 诊断发现三个根因：(1) v2.13.1 之前 cache 没 Playwright 字段 (2) `_dim_needs_fallback` 只看 `len(data)` 不看值质量 (3) skip 时无日志告诉用户为什么

--- a/docs/BUGS-LOG.md
+++ b/docs/BUGS-LOG.md
@@ -7,6 +7,64 @@
 
 ---
 
+## v2.13.3 (2026-04-19 · 51 评委规则全员历史立场还原)
+
+### BUG · 19 位评委给中际旭创 100 分 · 立场与历史严重不符
+- **症状**：用户截图报告 "彼得·林奇 100 分 · 看多 · PEG ≈ 63.253/60 < 1.5" 质疑"林奇历史上不会这么激进"。扫描面板发现 19 人 100 分（13 位游资 + 林奇 + 索罗斯 + 段永平 + 张坤 + 邓晓峰 etc），木头姐 13 分看空（CPO 是她赛道）
+- **位置**：`lib/investor_criteria.py` 多处规则 · `lib/investor_evaluator.py` · `lib/seat_db.py`
+- **5 处根因**：
+
+  1. **F 组游资射程反向判定**：`_youzi_base_rules` 把 `market_cap > min_mcap` 当打分依据 · 9456 亿对所有游资都"在射程" · 13 位游资误打 100/25。`is_in_range` 定义了但 evaluator 从未调用
+
+  2. **索罗斯反身性方向错**：`abs(upside_to_target) > 10` · 目标价 -63%（看空信号）也判"反身性差 = 看多 100"。`abs` 是 bug
+
+  3. **林奇 PEG 过松 + 无 PE 红线**：`peg_reasonable PEG < 1.5` 太松 · 无 PE 上限。但林奇原话 "PE should approximately equal growth rate" (PEG ≤ 1) 和 "PE > 40 like Rolls Royce"（历史持仓 Taco Bell 0.6/Hanes 0.2/Fannie Mae 0.6 均 PEG < 1）
+
+  4. **木头姐双 bug**：(a) `check=lambda f: f.get("industry_growth_pct", 0) > 20` · 但 stock_features v2.12.1 设的是 `industry_growth`（不带 _pct）· 中际旭创 40% 读成 0 · 判"增长太慢"看空。(b) 白名单缺 CPO/光模块/算力/数据中心/HBM · AI 基建本是 ARK 核心赛道
+
+  5. **中国价投派无 PE 红线**：段永平/张坤/邓晓峰 rules 只看 `pe_quantile_5y < 50` 不看绝对 PE · 高估值成长股也 100 分。历史：段买苹果 PE 18 / 茅台 PE 30；张坤重仓 PE 15-35 区间；邓晓峰偏左侧
+
+- **影响**：所有高 PE 成长股（CPO/光模块/AI/新能源等）的评委分布都被扭曲 · 5 大类评委立场都与历史不符 · 核心卖点"51 评委量化投票"的可信度崩塌
+
+- **修法**：
+  1. `seat_db.is_in_range` 加隐式 500 亿大市值上限 + `_MEGA_CAP_ALLOWLIST = {"章盟主"}`
+  2. `investor_evaluator.evaluate` 加 `_is_youzi_out_of_range` 前置检查 · F 组超射程 skip
+  3. `_youzi_base_rules` 移除 min_mcap/max_mcap 作为 Rule
+  4. SOROS_RULES 拆 `sentiment_long_reflex`（只 upside > +10 pass）+ `sentiment_short_reflex_penalty`（upside < -15 扣分）
+  5. LYNCH_RULES 6 条：`peg_ideal (PEG<1, 5分)` + `peg_acceptable (PEG 1-1.5, 3分)` + `pe_not_rolls_royce (PE<40, 3分)` + `fast_grower_zone (20-50%, 3分)` + `understandable (2)` + `research_support (2)`
+  6. WOOD_RULES 字段兼容 `industry_growth` · 白名单加 CPO/光模块/算力等 12 词
+  7. DUAN_RULES/ZHANGKUN_RULES/DENGXIAOFENG_RULES 各加 `pe_not_expensive`（PE<40/40/35）
+
+- **验证**（300308.SZ 实测）：
+  | 评委 | v2.13.2 | v2.13.3 |
+  |---|---|---|
+  | 林奇 | 100 bullish | 38 neutral |
+  | 索罗斯 | 100 bullish | 42 neutral |
+  | 段永平 | 100 bullish | 84 bullish |
+  | 张坤 | 100 bullish | 78 bullish |
+  | 邓晓峰 | 100 bullish | 76 bullish |
+  | 木头姐 | 13 bearish | 80 bullish |
+  | F 组 22 位游资 | 全打分 | 全 skip（射程外） |
+  - 100 分从 19 人 → 5 人 · skip 从 1 → 23 人
+
+- **回归测试**：`tests/test_v2_13_3_investor_rules.py` 15 用例
+  - F 组：out_of_range / allowlist 章盟主 / small cap in range / 非游资不受影响
+  - 索罗斯：+30 bullish / -63 bearish / +5 neutral 三方向
+  - 林奇：PEG < 1 / PE 63 reject / PEG 1-1.5 临界
+  - 木头姐：CPO 识别 + industry_growth 新字段兼容
+  - 段永平/张坤：PE 63 扣分 + PE 30 高分护栏
+  - 全量 173 passed（v2.13.2 158 + 新 15）
+
+- **若未来改评委规则**：
+  - **核心护栏 · 林奇的 PE 40 红线不能去掉**（历史持仓数据支撑 · Rolls Royce 原话）
+  - **索罗斯反身性 abs() 绝对值是已知反向 bug**（目标价 -63% 不是 "反身性差 = 看多"）
+  - **F 组游资必须 is_in_range 前置 skip**（大市值股游资不玩 · 9000 亿拉不动）
+  - **中国价投派 PE 红线对应各自历史风格**（段 40 / 张 40 / 邓 35）· 改动需说明历史出处
+  - **木头姐字段名用 `industry_growth` 口径**（与 stock_features 保持一致 · v2.12.1 字段）
+  - 加新评委规则要同时加历史依据（书/年报/访谈 URL）到 `lib/investor_knowledge.py`
+
+---
+
 ## v2.13.2 (2026-04-19 · Playwright 触发逻辑升级 · 数据质量感知 + FORCE flag)
 
 ### BUG · 维度有 data 但值都是 "—"/空时 Playwright 兜底未触发

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stock-deep-analyzer",
-  "version": "2.13.2",
+  "version": "2.13.3",
   "description": "A股/港股/美股个股深度分析引擎 · 22维数据 × 51位大佬量化评委 · 17种机构级分析方法 | A-share / HK / US deep-analysis · 22 dims × 51-investor jury × 17 institutional methods",
   "type": "module",
   "author": "FloatFu-true",

--- a/skills/deep-analysis/scripts/lib/investor_criteria.py
+++ b/skills/deep-analysis/scripts/lib/investor_criteria.py
@@ -171,19 +171,45 @@ KLARMAN_RULES = [
 # B 组 · 成长投资派 (4 人)
 # ═══════════════════════════════════════════════════════════════
 
+# v2.13.3 · 林奇方法论还原 · 依据 One Up on Wall Street (1989) / Beating the Street (1993)
+# 关键原则：
+# 1. "PE should be approximately equal to growth rate" · PEG ≈ 1 是理想
+# 2. "PE > 40 like buying a Rolls Royce" · 40 是 PE 警戒线
+# 3. Fast grower sweet spot：20-50% growth
+# 4. 历史持仓 PEG 几乎都 < 1（Taco Bell 0.6 / Hanes 0.2 / Ford / Fannie Mae 0.6）
+def _peg(f):
+    """PEG = PE / growth rate · 缺失时返 999（fail 所有 PEG rules）."""
+    pe = f.get("pe", 0) or 0
+    growth = f.get("revenue_growth_latest", 0) or 0
+    if pe <= 0 or growth <= 0:
+        return 999
+    return pe / growth
+
+
 LYNCH_RULES = [
-    Rule("peg_reasonable", "PEG < 1.5 (PEG=PE/增速)", 5,
-         check=lambda f: 0 < f.get("pe", 0) / max(f.get("revenue_growth_latest", 1), 1) < 1.5,
-         pass_msg="PEG ≈ {pe}/{revenue_growth_latest:.0f} < 1.5",
-         fail_msg="PEG 不够吸引"),
-    Rule("fast_grower", "营收增速 > 20%", 4,
-         check=lambda f: f.get("revenue_growth_latest", 0) > 20,
-         pass_msg="营收增速 {revenue_growth_latest:.1f}%",
-         fail_msg="营收增速仅 {revenue_growth_latest:.1f}%"),
+    # 核心：PEG < 1 · 林奇理想值（真实历史阈值）
+    Rule("peg_ideal", "PEG < 1 (林奇理想值)", 5,
+         check=lambda f: 0 < _peg(f) < 1.0,
+         pass_msg="PEG ≈ {pe}/{revenue_growth_latest:.0f} < 1 (林奇理想)",
+         fail_msg="PEG 未进入林奇理想区间 (< 1)"),
+    # 次优：PEG 1-1.5 临界接受
+    Rule("peg_acceptable", "PEG 1-1.5 (临界接受)", 3,
+         check=lambda f: 1.0 <= _peg(f) < 1.5,
+         pass_msg="PEG ≈ {pe}/{revenue_growth_latest:.0f} · 临界接受",
+         fail_msg="PEG 不在 1-1.5 临界区"),
+    # v2.13.3 新增 · PE 40 警戒线（林奇原话 "Rolls Royce" 级别）
+    Rule("pe_not_rolls_royce", "PE < 40 (林奇警戒线)", 3,
+         check=lambda f: 0 < f.get("pe", 999) < 40,
+         pass_msg="PE {pe:.0f} 在舒适区",
+         fail_msg="PE {pe:.0f} > 40 · 林奇警戒（Rolls Royce 不是必要品）"),
+    # Fast grower sweet spot 20-50%
+    Rule("fast_grower_zone", "营收增速 20-50% (林奇 fast grower sweet spot)", 3,
+         check=lambda f: 20 < f.get("revenue_growth_latest", 0) < 50,
+         pass_msg="营收增速 {revenue_growth_latest:.0f}% · fast grower",
+         fail_msg="增速 {revenue_growth_latest:.0f}% 超出 20-50% 区间"),
     Rule("understandable", "行业好懂", 2,
          check=lambda f: True,
-         pass_msg="行业易理解",
-         fail_msg="—"),
+         pass_msg="行业易理解"),
     Rule("research_support", "研报覆盖中性偏上", 2,
          check=lambda f: f.get("research_coverage", 0) >= 5 and f.get("buy_rating_pct", 0) >= 60,
          pass_msg="{research_coverage:.0f} 家研报 · 买入 {buy_rating_pct:.0f}%",
@@ -232,18 +258,32 @@ THIEL_RULES = [
          fail_msg="规模优势不足"),
 ]
 
+# v2.13.3 · 木头姐方法论还原 · ARK Invest 五大颠覆性创新平台
+# 两处 bug 修复：
+# 1. 字段名错：读 industry_growth_pct · 实际 stock_features 设的是 industry_growth
+#    结果中际旭创（光模块行业增速 40%）读成 0 · 被误判"增长太慢"
+# 2. 白名单缺 CPO/光模块/算力/数据中心/HBM 等 AI 基建关键词 ·
+#    ARK 实际持 NVDA/TSM/Palantir 等 AI 上下游 · 光模块绝对在她视野里
 WOOD_RULES = [
     Rule("s_curve", "行业处于 S 曲线拐点 (TAM > 20%/年)", 5,
-         check=lambda f: f.get("industry_growth_pct", 0) > 20,
-         pass_msg="行业增速 {industry_growth_pct:.0f}% — S 曲线拐点",
-         fail_msg="行业增速 {industry_growth_pct:.0f}% < 20%，增长太慢"),
+         # v2.13.3 · 字段名统一为 industry_growth（stock_features 口径）
+         check=lambda f: (f.get("industry_growth") or f.get("industry_growth_pct", 0)) > 20,
+         pass_msg="行业增速 {industry_growth:.0f}% — S 曲线拐点",
+         fail_msg="行业增速 {industry_growth:.0f}% < 20%，增长太慢"),
     Rule("innovation_platform", "属于 ARK 颠覆式创新平台", 5,
          check=lambda f: any(kw in (f.get("industry", "") + " " + f.get("name", "")).lower()
-                            for kw in ["光学", "半导体", "电池", "锂电", "AI", "人工智能",
-                                       "生物", "基因", "机器人", "量子", "空间", "卫星",
-                                       "AR", "VR", "自动驾驶", "新能源", "储能",
-                                       "3D打印", "区块链", "数字货币", "mRNA",
-                                       "脑机", "核聚变"]),
+                            for kw in [
+                                # 原有 · AI / 半导体 / 生物 / 新能源 等
+                                "光学", "半导体", "电池", "锂电", "AI", "人工智能",
+                                "生物", "基因", "机器人", "量子", "空间", "卫星",
+                                "AR", "VR", "自动驾驶", "新能源", "储能",
+                                "3D打印", "区块链", "数字货币", "mRNA",
+                                "脑机", "核聚变",
+                                # v2.13.3 新增 · AI 算力基建 · CPO/光模块等
+                                "光模块", "CPO", "光芯片", "算力", "数据中心",
+                                "IDC", "HBM", "gpu", "通信设备", "光通信",
+                                "云计算", "服务器", "存储芯片",
+                            ]),
          pass_msg="🔮 属于颠覆式创新平台 — 这是我们的菜！",
          fail_msg="不在 ARK 五大创新平台范畴"),
     Rule("revenue_acceleration", "营收加速或高增长", 3,
@@ -261,10 +301,21 @@ WOOD_RULES = [
 # ═══════════════════════════════════════════════════════════════
 
 SOROS_RULES = [
-    Rule("sentiment_divergence", "价格偏离基本面 (研报目标价 vs 现价差 > 10%)", 4,
-         check=lambda f: abs(f.get("upside_to_target", 0)) > 10,
-         pass_msg="研报目标涨幅 {upside_to_target:.0f}% (反身性差)",
-         fail_msg="价格与基本面共识"),
+    # v2.13.3 · 修反身性判定方向错误
+    # 原 bug：abs(upside) > 10 → 目标价 -63%（看跌）也 pass 打"反身性差"看多
+    # 修：只在 upside > 10%（研报认为显著低估）时 pass · 做多反身性信号
+    # 研报看跌场景（upside < -10）不在本 rule 处理 · 应由下方 bearish rule 识别
+    Rule("sentiment_long_reflex", "研报目标价显著高于现价 > 10% (做多反身性机会)", 4,
+         check=lambda f: f.get("upside_to_target", 0) > 10,
+         pass_msg="研报目标涨幅 {upside_to_target:.0f}% · 市场过度悲观 · 做多反身性",
+         fail_msg="价格不低于基本面共识 · 无做多反身性空间"),
+    # v2.13.3 新增 · 识别做空反身性（价格 >>  基本面预期）
+    # 索罗斯著名空单：1992 英镑、2010 黄金、2013 日元 · 都是价格超涨做空
+    # 目标价低于现价 -15% 以上 · 说明市场狂热脱离基本面
+    Rule("sentiment_short_reflex_penalty", "研报目标价低于现价 > 15% (做空反身性 · 做多方减分)", 4,
+         check=lambda f: f.get("upside_to_target", 0) > -15,
+         pass_msg="研报目标涨幅 {upside_to_target:.0f}% · 未到狂热",
+         fail_msg="研报目标涨幅 {upside_to_target:.0f}% · 市场过度狂热 · 索罗斯会考虑做空"),
     Rule("macro_tailwind", "宏观环境配合", 3,
          check=lambda f: f.get("macro_rate_easing", False),
          pass_msg="利率周期 {macro_rate_cycle}",
@@ -412,6 +463,12 @@ DUAN_RULES = [
          check=lambda f: f.get("pe_quantile_5y", 100) < 50,
          pass_msg="PE {pe_quantile_5y} 分位",
          fail_msg="价格不对，PE {pe_quantile_5y} 分位"),
+    # v2.13.3 · 段永平 PE 红线（历史买入苹果 PE~18 · 茅台 PE~30 · 腾讯 PE~25 都是相对便宜时介入）
+    # 原话：买股票跟买公司一样，关键是"价"要合理。对 PE 50+ 他永远说 "贵了"
+    Rule("pe_not_expensive", "PE 不超过 40 (段永平价格红线)", 3,
+         check=lambda f: 0 < f.get("pe", 999) < 40,
+         pass_msg="PE {pe:.0f} 在段永平舒适区",
+         fail_msg="PE {pe:.0f} 太贵 · 段永平历史买入都是相对便宜时"),
     Rule("long_term_clear", "10 年看得懂 (护城河 + 成熟业务)", 3,
          check=lambda f: f.get("moat_total", 0) >= 22 and f.get("consecutive_profit_years", 0) >= 5,
          pass_msg="商业模式可见 10 年",
@@ -431,6 +488,11 @@ ZHANGKUN_RULES = [
          check=lambda f: f.get("moat_intangible", 0) >= 7,
          pass_msg="无形资产 {moat_intangible:.0f}/10",
          fail_msg="品牌壁垒不强"),
+    # v2.13.3 · 张坤历史重仓茅台/五粮液/腾讯 PE 15-35 之间 · 不碰 PE > 40
+    Rule("pe_discipline", "PE 不超过 40 (张坤估值纪律)", 3,
+         check=lambda f: 0 < f.get("pe", 999) < 40,
+         pass_msg="PE {pe:.0f} 符合张坤估值纪律",
+         fail_msg="PE {pe:.0f} 超出张坤历史持仓估值上限"),
 ]
 
 ZHUSHAOXING_RULES = [
@@ -483,6 +545,11 @@ DENGXIAOFENG_RULES = [
          check=lambda f: f.get("roic", 0) > 10 or f.get("roe_latest", 0) > 12,
          pass_msg="价值创造 ROIC/ROE 达标",
          fail_msg="价值创造不足"),
+    # v2.13.3 · 邓晓峰偏价值风格 · 历史持仓白酒/地产/银行/周期股 PE 都偏低
+    Rule("pe_reasonable", "PE 不超过 35 (邓晓峰偏左侧)", 3,
+         check=lambda f: 0 < f.get("pe", 999) < 35,
+         pass_msg="PE {pe:.0f} 偏左侧符合邓晓峰风格",
+         fail_msg="PE {pe:.0f} 过高 · 邓晓峰偏左侧出击"),
     Rule("good_price", "恰当价格 (PE 分位 < 60)", 3,
          check=lambda f: f.get("pe_quantile_5y", 100) < 60,
          pass_msg="PE 分位 {pe_quantile_5y}",
@@ -494,24 +561,16 @@ DENGXIAOFENG_RULES = [
 # ═══════════════════════════════════════════════════════════════
 
 def _youzi_base_rules(min_mcap=None, max_mcap=None, need_stage_2=True, need_lhb=False, need_sector_leader=False):
-    """Generate standard 游资 rules."""
+    """Generate standard 游资 rules.
+
+    v2.13.3 · min_mcap/max_mcap 不再作为 Rule 打分（避免"市值超标"反向判看多/看空）。
+    市值射程由 investor_evaluator._is_youzi_out_of_range 前置 skip 处理。
+    这里的 min_mcap/max_mcap 参数保留是为了 seat_db 仍能读取射程定义，不影响规则评分。
+    """
     rules = []
-    if min_mcap is not None:
-        rules.append(Rule(
-            "min_mcap", f"市值 > {min_mcap} 亿",
-            3,
-            check=lambda f, mc=min_mcap: f.get("market_cap_yi", 0) > mc,
-            pass_msg=f"市值 {{market_cap_yi:.0f}} 亿 > {min_mcap} 亿",
-            fail_msg=f"市值 {{market_cap_yi:.0f}} 亿 < {min_mcap} 亿 不在射程"
-        ))
-    if max_mcap is not None:
-        rules.append(Rule(
-            "max_mcap", f"市值 < {max_mcap} 亿",
-            3,
-            check=lambda f, mc=max_mcap: f.get("market_cap_yi", 0) < mc,
-            pass_msg=f"市值 {{market_cap_yi:.0f}} 亿 < {max_mcap} 亿",
-            fail_msg=f"市值 {{market_cap_yi:.0f}} 亿 超 {max_mcap} 亿"
-        ))
+    # v2.13.3 · 移除 min_mcap / max_mcap 作为 Rule
+    # 原版 bug：市值 > min_mcap = pass 给分 · 导致 9000+ 亿大盘股对每个游资都"在射程"
+    # 现在由 evaluator 前置 skip 处理（超 500 亿默认跳过）
     if need_stage_2:
         rules.append(Rule(
             "stage_2", "Stage 2 上升",

--- a/skills/deep-analysis/scripts/lib/investor_evaluator.py
+++ b/skills/deep-analysis/scripts/lib/investor_evaluator.py
@@ -28,6 +28,39 @@ from lib.investor_db import INVESTORS as _INVESTORS
 
 # v2.8 · 预构建 id → group 索引，用于 profile 的 group-level fallback
 _INVESTOR_GROUP_MAP: dict[str, str] = {inv["id"]: inv.get("group", "") for inv in _INVESTORS}
+# v2.13.3 · F 组射程检查用：id → 中文 name（供 seat_db.is_in_range 查 SEATS key）
+_INVESTOR_NAME_MAP: dict[str, str] = {inv["id"]: inv.get("name", "") for inv in _INVESTORS}
+
+
+def _is_youzi_out_of_range(investor_id: str, features: dict) -> tuple[bool, str]:
+    """v2.13.3 · F 组游资射程前置检查.
+
+    对 F 组投资者 · 调 seat_db.is_in_range · 不在射程则 skip（不打分）.
+    解决 v2.13.2 之前"大市值股对所有游资都判看多/看空"的 bug.
+
+    Returns:
+        (out_of_range: bool, reason: str)
+    """
+    if _INVESTOR_GROUP_MAP.get(investor_id) != "F":
+        return False, ""
+    try:
+        from lib.seat_db import SEATS, is_in_range
+    except Exception:
+        return False, ""
+    nickname = _INVESTOR_NAME_MAP.get(investor_id, "")
+    if not nickname or nickname not in SEATS:
+        return False, ""  # seat 没定义 · 不做 skip 决策
+    # is_in_range 需要 market_cap 字段（元）· features 里常叫 market_cap_yi（亿）或 market_cap
+    mc = features.get("market_cap") or 0
+    # 兼容：features 可能只有 market_cap_yi（亿）· 换算为元
+    if not mc and features.get("market_cap_yi"):
+        mc = float(features["market_cap_yi"]) * 1e8
+    probe = dict(features)
+    probe["market_cap"] = mc
+    if not is_in_range(nickname, probe):
+        mc_yi = mc / 1e8 if mc else 0
+        return True, f"市值 {mc_yi:.0f} 亿不在 {nickname} 射程"
+    return False, ""
 
 
 # ────────────────────────────────────────────────────────────────
@@ -88,6 +121,11 @@ def evaluate(investor_id: str, features: dict) -> dict:
     # If this investor wouldn't look at this market at all → "不适合"
     if not rc["should_evaluate"]:
         return _skip_result(investor_id, rc["skip_reason"] or "不在能力圈")
+
+    # v2.13.3 · F 组游资射程前置检查 · 大市值超射程直接 skip 不打分
+    out_of_range, range_reason = _is_youzi_out_of_range(investor_id, features)
+    if out_of_range:
+        return _skip_result(investor_id, range_reason)
 
     rules: list[Rule] = INVESTOR_RULES.get(investor_id, [])
     if not rules:

--- a/skills/deep-analysis/scripts/lib/seat_db.py
+++ b/skills/deep-analysis/scripts/lib/seat_db.py
@@ -229,9 +229,19 @@ def match_seats_in_lhb(lhb_records: list[dict]) -> dict[str, list[dict]]:
     return matches
 
 
+# v2.13.3 · 游资通用大市值上界（元）· fit_rules 未显式设 max_mcap 时生效
+# 理由：A 股游资几乎不玩 500 亿以上大盘股（流动性不足以拉动 · 外资/机构主场）
+# 例外：章盟主做过茅台大盘（2020 牛市）· 单独 allowlist 不限上限
+FALLBACK_YOUZI_MAX_MCAP_YUAN = 50_000_000_000  # 500 亿元
+_MEGA_CAP_ALLOWLIST = frozenset({"章盟主"})  # 可做大盘的游资
+
+
 def is_in_range(nickname: str, ticker_features: dict) -> bool:
     """Check if a stock fits a 游资's射程 based on its fit_rules.
     ticker_features should provide: market_cap, trend, is_sector_leader, sentiment_cycle, etc.
+
+    v2.13.3 升级：对未显式设 max_mcap 的游资，隐式用 500 亿上限（除非在 allowlist）。
+    原因：A 股游资实操不碰超大盘，9000+ 亿这种根本拉不动。
     """
     info = SEATS.get(nickname)
     if not info:
@@ -242,6 +252,10 @@ def is_in_range(nickname: str, ticker_features: dict) -> bool:
         return False
     if "max_mcap" in rules and mc > rules["max_mcap"]:
         return False
+    # v2.13.3 · 隐式大市值上限
+    if "max_mcap" not in rules and nickname not in _MEGA_CAP_ALLOWLIST:
+        if mc > FALLBACK_YOUZI_MAX_MCAP_YUAN:
+            return False
     for k, v in rules.items():
         if k.startswith(("min_", "max_")):
             continue

--- a/skills/deep-analysis/scripts/tests/test_v2_13_3_investor_rules.py
+++ b/skills/deep-analysis/scripts/tests/test_v2_13_3_investor_rules.py
@@ -1,0 +1,254 @@
+"""Regression tests for v2.13.3 · 评委规则历史立场还原.
+
+中际旭创 300308 实测暴露：
+- 19 人给 100 分（含 13 位游资 · Lynch / Soros / 段永平 / 张坤 / 邓晓峰 等）
+- 木头姐 13 分看空（实际 CPO 是她的赛道）
+- 游资 "市值超 80 亿 = 看空" 等反向判定
+
+本测试验证 v2.13.3 修复：
+1. 游资射程 · 大市值（> 500 亿默认）应 skip 不是 bullish/bearish
+2. 索罗斯反身性方向正确（只做多 upside > 10% · 不把 -63% 也当看多信号）
+3. 林奇 PEG < 1 ideal · PE > 40 红线
+4. 木头姐字段名修正 + CPO/光模块/算力白名单
+5. 段永平/张坤/邓晓峰 PE 红线
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+SCRIPTS = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(SCRIPTS))
+
+
+# ─── Fix 1 · 游资射程 ────────────────────────────────────────────
+
+def test_youzi_out_of_range_for_mega_cap():
+    """9456 亿大盘股不在任何常规游资的射程（章盟主 allowlist 除外）."""
+    from lib.investor_evaluator import _is_youzi_out_of_range
+    features = {"market_cap_yi": 9456, "market_cap": 9456e8, "stage_num": 2}
+    # 大部分游资（无 max_mcap 的）都应 skip 超大盘
+    out, reason = _is_youzi_out_of_range("sun_ge", features)
+    assert out is True
+    assert "9456" in reason or "射程" in reason
+
+    out, reason = _is_youzi_out_of_range("zhao_lg", features)
+    assert out is True
+
+    out, reason = _is_youzi_out_of_range("fs_wyj", features)  # 佛山无影脚 max_mcap=80 亿
+    assert out is True
+
+
+def test_zhang_mz_allowlist_can_play_mega_cap():
+    """章盟主在 allowlist 里 · 9456 亿不应 skip."""
+    from lib.investor_evaluator import _is_youzi_out_of_range
+    features = {"market_cap_yi": 9456, "market_cap": 9456e8, "stage_num": 2, "trend": "up"}
+    out, reason = _is_youzi_out_of_range("zhang_mz", features)
+    # 章盟主 fit_rules min_mcap=200 亿 + allowlist 绕过 500 亿隐式上限 · in-range
+    assert out is False
+
+
+def test_youzi_in_range_for_small_cap():
+    """50-150 亿小盘股应 in range（常规游资射程内）."""
+    from lib.investor_evaluator import _is_youzi_out_of_range
+    features = {"market_cap_yi": 100, "market_cap": 100e8, "stage_num": 2, "trend": "up",
+                "is_sector_leader": True}
+    # sun_ge fit_rules min_mcap=10亿 + needs is_sector_leader
+    out, reason = _is_youzi_out_of_range("sun_ge", features)
+    assert out is False, f"100 亿 + sector leader 应在 sun_ge 射程, got {reason}"
+
+
+def test_non_youzi_investor_not_affected():
+    """非 F 组（巴菲特等）不受射程检查影响."""
+    from lib.investor_evaluator import _is_youzi_out_of_range
+    features = {"market_cap_yi": 9456, "market_cap": 9456e8}
+    out, _ = _is_youzi_out_of_range("buffett", features)
+    assert out is False
+    out, _ = _is_youzi_out_of_range("lynch", features)
+    assert out is False
+
+
+# ─── Fix 2 · 索罗斯反身性方向 ────────────────────────────────────
+
+def test_soros_bullish_on_positive_upside():
+    """研报目标价 +30% · 做多反身性 pass."""
+    from lib.investor_evaluator import evaluate
+    features = {
+        "market": "A", "ticker": "600519.SH", "name": "贵州茅台", "industry": "白酒",
+        "upside_to_target": 30,
+        "macro_rate_easing": True,
+        "stage_num": 2,
+    }
+    r = evaluate("soros", features)
+    # upside 30% · pass sentiment_long_reflex (4 分) + penalty pass (4 分) + macro (3) + stage (3)
+    # = 14/14 = 100 分
+    assert r["score"] > 70
+
+
+def test_soros_bearish_on_extreme_negative_upside():
+    """研报目标价 -63%（狂热高位）· 做多方面 fail · 应 bearish or neutral."""
+    from lib.investor_evaluator import evaluate
+    features = {
+        "market": "A", "ticker": "300308.SZ", "name": "中际旭创", "industry": "通信设备",
+        "upside_to_target": -63,
+        "macro_rate_easing": False,
+        "stage_num": 2,
+    }
+    r = evaluate("soros", features)
+    # upside -63% fail sentiment_long_reflex · fail sentiment_short_penalty · pass stage (3)
+    # = 3/14 ≈ 21 分 · bearish
+    assert r["score"] < 50, f"索罗斯对 -63% upside 应 bearish · got {r['score']}"
+
+
+def test_soros_neutral_on_small_upside():
+    """±10% 以内 · 无反身性机会 · 中性."""
+    from lib.investor_evaluator import evaluate
+    features = {
+        "market": "A", "ticker": "600519.SH", "name": "test", "industry": "white",
+        "upside_to_target": 5,
+        "macro_rate_easing": False,
+        "stage_num": 1,
+    }
+    r = evaluate("soros", features)
+    # upside 5 fail long_reflex · pass penalty (4) · fail macro / stage
+    assert r["score"] < 60
+
+
+# ─── Fix 3 · 林奇 PEG + PE 红线 ─────────────────────────────────
+
+def test_lynch_ideal_peg_under_1():
+    """PEG < 1 · 林奇理想 · 高分."""
+    from lib.investor_evaluator import evaluate
+    features = {
+        "market": "A", "ticker": "test", "name": "test", "industry": "消费",
+        "pe": 15,
+        "revenue_growth_latest": 20,  # PEG = 0.75
+        "research_coverage": 10,
+        "buy_rating_pct": 70,
+    }
+    r = evaluate("lynch", features)
+    # peg_ideal (5) + pe_not_rolls_royce (3) + fast_grower_zone (3) + understandable (2) + research (2)
+    # = 15/18 ≈ 83
+    assert r["score"] > 70
+
+
+def test_lynch_rejects_pe_over_40():
+    """PE 63 + 增速 40% · PEG 1.58 · 林奇不会 100 分 · PE 40 红线触发."""
+    from lib.investor_evaluator import evaluate
+    features = {
+        "market": "A", "ticker": "300308.SZ", "name": "中际旭创", "industry": "通信设备",
+        "pe": 63,
+        "revenue_growth_latest": 40,  # PEG = 1.575 · 超出 1.5
+        "research_coverage": 20,
+        "buy_rating_pct": 80,
+    }
+    r = evaluate("lynch", features)
+    # peg_ideal fail · peg_acceptable fail (1.575 >= 1.5) · pe_not_rolls_royce fail (63 > 40)
+    # · fast_grower_zone pass (40% in 20-50) · understandable pass · research pass
+    # = 7/18 ≈ 39 分 · 不是 100！
+    assert r["score"] < 50, f"PE 63 林奇应 < 50 分, got {r['score']}"
+
+
+def test_lynch_peg_acceptable_zone():
+    """PEG 1.0-1.5 临界接受."""
+    from lib.investor_evaluator import evaluate
+    features = {
+        "market": "A", "ticker": "test", "name": "test", "industry": "消费",
+        "pe": 30,
+        "revenue_growth_latest": 25,  # PEG = 1.2 · fast_grower 25 in (20,50)
+        "research_coverage": 10,
+        "buy_rating_pct": 70,
+    }
+    r = evaluate("lynch", features)
+    # peg_ideal fail · peg_acceptable pass (3) · pe_not_rolls_royce pass (3) ·
+    # fast_grower_zone pass (3) · understandable (2) · research (2) = 13/18 ≈ 72
+    assert 55 < r["score"] < 85
+
+
+# ─── Fix 4 · 木头姐 ─────────────────────────────────────────────
+
+def test_wood_bullish_on_cpo_optical_module():
+    """中际旭创（CPO/光模块/通信设备/AI 算力）应是木头姐的菜 · 高分看多."""
+    from lib.investor_evaluator import evaluate
+    features = {
+        "market": "A", "ticker": "300308.SZ", "name": "中际旭创", "industry": "通信设备",
+        "industry_growth": 40,  # v2.13.3 字段名
+        "rev_growth_3y": 50,
+        "max_drawdown_1y": -25,
+    }
+    r = evaluate("wood", features)
+    # s_curve pass (40 > 20) · innovation_platform pass ("通信设备" 在白名单)
+    # · revenue_acceleration pass · long_term_view pass = 15/15 = 100
+    assert r["score"] > 85, f"光模块应是木头姐的菜, got {r['score']}"
+
+
+def test_wood_uses_industry_growth_not_pct():
+    """确保 WOOD_RULES 读 industry_growth（新字段）· 老 industry_growth_pct fallback."""
+    from lib.investor_evaluator import evaluate
+    # 只提供 industry_growth · 不提供 industry_growth_pct
+    features = {
+        "market": "A", "ticker": "test", "name": "test", "industry": "AI",
+        "industry_growth": 35,  # 新字段
+        "rev_growth_3y": 30,
+        "max_drawdown_1y": -20,
+    }
+    r = evaluate("wood", features)
+    assert r["score"] > 70, "新字段 industry_growth=35 应 pass s_curve rule"
+
+
+# ─── Fix 5 · 中国价投派 PE 红线 ─────────────────────────────────
+
+def test_duan_rejects_pe_over_40():
+    """段永平 PE 63 应明显扣分."""
+    from lib.investor_evaluator import evaluate
+    features = {
+        "market": "A", "ticker": "300308.SZ", "name": "中际旭创", "industry": "通信设备",
+        "pe": 63,
+        "net_margin": 28,
+        "roe_latest": 44,
+        "pe_quantile_5y": 55,  # fail good_price
+        "moat_total": 26,
+        "consecutive_profit_years": 8,
+    }
+    r = evaluate("duan", features)
+    # good_business pass (5) · good_people pass default (4) · good_price fail (55>50)
+    # · pe_not_expensive fail (63>40 · -3) · long_term_clear pass (3) = 12/19 ≈ 63
+    # v2.13.3 加 PE 红线扣 3 分 · 原版会是 12/16 = 75
+    # 关键：PE 63 导致分数 < 80（不再 100）
+    assert r["score"] < 80, f"段永平 PE 63 应扣分，got {r['score']}"
+
+
+def test_zhangkun_rejects_pe_over_40():
+    """张坤 PE 63 应触发估值纪律扣分."""
+    from lib.investor_evaluator import evaluate
+    features = {
+        "market": "A", "ticker": "300308.SZ", "name": "中际旭创", "industry": "通信设备",
+        "pe": 63,
+        "roe_5y_above_15": 5,
+        "net_margin": 25,
+        "moat_intangible": 8,
+    }
+    r = evaluate("zhangkun", features)
+    # roe_persistent pass (5) + pricing_power pass (3) + moat_brand pass (3) + pe_discipline fail (3)
+    # = 11/14 ≈ 79 分（原来没 pe_discipline 就是 100）
+    assert r["score"] < 90, f"张坤 PE 63 应触发估值纪律，got {r['score']}"
+
+
+def test_value_investors_accept_pe_under_40():
+    """PE < 40 价值派应正常高分."""
+    from lib.investor_evaluator import evaluate
+    features = {
+        "market": "A", "ticker": "test", "name": "test", "industry": "白酒",
+        "pe": 30,
+        "net_margin": 28,
+        "roe_latest": 30,
+        "roe_5y_above_15": 5,
+        "pe_quantile_5y": 30,
+        "moat_total": 26,
+        "moat_intangible": 9,
+        "consecutive_profit_years": 10,
+    }
+    r1 = evaluate("duan", features)
+    r2 = evaluate("zhangkun", features)
+    assert r1["score"] > 80, f"段永平 PE 30 应高分, got {r1['score']}"
+    assert r2["score"] > 80, f"张坤 PE 30 应高分, got {r2['score']}"


### PR DESCRIPTION
## Summary

用户反馈"林奇 100 分过于激进"。面板扫描发现 **19 人给中际旭创 100 分**，立场与历史不符。

### 5 大类修复

| # | 问题 | 影响 |
|---|---|---|
| 1 | F 组游资射程反向 | 13 位游资误打 100/25 → 22 人 skip |
| 2 | 索罗斯 abs(upside) · 方向错 | 100→42 |
| 3 | 林奇无 PE 40 红线 | 100→38 |
| 4 | 木头姐字段名 + 白名单缺 CPO/光模块 | 13 看空→80 看多 |
| 5 | 段永平/张坤/邓晓峰无 PE 红线 | 100→84/78/76 |

### 历史依据

- 林奇：One Up on Wall Street · Taco Bell 0.6 / Hanes 0.2 · "PE > 40 like Rolls Royce"
- 索罗斯：反身性要看方向 · abs() 是 bug
- 段永平：苹果 PE 18 / 茅台 PE 30 介入
- 张坤：持仓 PE 15-35 区间
- 木头姐：ARK 实持 NVDA/TSM · CPO 是 AI 基建赛道核心

### Test plan

- [x] pytest 173 passed（v2.13.2 158 + 新 15）
- [x] 300308.SZ 真机验证 · 100 分 19→5 · consensus 78→81.4
- [x] 各评委立场符合历史真实

🤖 Generated with [Claude Code](https://claude.com/claude-code)