### PR TITLE
v2.13.5: NetworkProfile 自适应 + agent HARD-GATE 主动触发 Playwright

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "stock-deep-analyzer",
-  "version": "2.13.4",
+  "version": "2.13.5",
   "description": "A股/港股/美股个股深度分析引擎 · 22维数据 × 51位大佬量化评委 × 17种机构级分析方法 · 杀猪盘检测 · Bloomberg风格HTML报告 | A-share / HK / US stock deep-analysis with first-class Chinese-market coverage — 22 data dims × 51-investor jury × 17 institutional methods · trap detection · Bloomberg-style HTML report",
   "author": {
     "name": "FloatFu-true",

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "stock-deep-analyzer",
   "description": "A股/港股/美股个股深度分析引擎 · 22维数据 × 51位大佬量化评委 · 17种机构级分析方法 | A-share / HK / US deep-analysis · 22 dims × 51-investor jury × 17 institutional methods",
-  "version": "2.13.4",
+  "version": "2.13.5",
   "author": {
     "name": "FloatFu-true"
   },

--- a/.version-bump.json
+++ b/.version-bump.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.13.4",
+  "version": "2.13.5",
   "files": [
     ".claude-plugin/plugin.json",
     ".cursor-plugin/plugin.json",

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -64,7 +64,44 @@ Do NOT proceed to report generation until you have:
 5. SET agent_reviewed: true in agent_analysis.json
 </HARD-GATE>
 
-Stage 1 跑完后，你必须：
+### ⛔ Step 3.0 · Playwright 兜底前置检查（v2.13.5 必走）
+
+Stage 1 跑完后 · 开始 role-play **之前**：
+
+```python
+import json, os
+from pathlib import Path
+
+# 1. 读网络 profile · 了解能抓哪些源
+net_path = Path(".cache/_global/network_profile.json")
+if net_path.exists():
+    net = json.loads(net_path.read_text(encoding="utf-8"))
+    print(f"网络: {net['recommendation']}")  # 比如"国内通 · 境外受限"
+
+# 2. 读自查 issues 找数据不足的维度
+issues_path = Path(f".cache/{ticker}/_review_issues.json")
+if issues_path.exists():
+    issues = json.loads(issues_path.read_text(encoding="utf-8"))
+    low_q = [
+        i["dim"] for i in issues.get("issues", [])
+        if i.get("category") == "data" and i.get("severity") in ("critical", "warning")
+    ]
+
+# 3. 如果 low_q 非空 · 主动强制跑一次 Playwright 兜底
+if low_q:
+    os.environ["UZI_PLAYWRIGHT_FORCE"] = "1"
+    from lib.playwright_fallback import autofill_via_playwright
+    summary = autofill_via_playwright(raw, ticker)
+    # summary.succeeded > 0 → 某些维度已被 Playwright 补齐 · 继续 role-play 时这些维度有真实数据了
+```
+
+**为什么这个 HARD-GATE**：v2.13.5 之前 agent 经常看到 `data.growth = "—"` 就在
+commentary 里写 "增速待补充"，但脚本其实可以用 Playwright 从百度/东财 F10/雪球
+抓到数据 · agent 没主动调就浪费了。
+
+Playwright 也抓不到的维度 · 再用 WebSearch / mx_api / 常识补（并标注"基于公开信息推断"）。
+
+### Step 3.1 你来做评委 role-play
 
 **3a. 读取 `.cache/{ticker}/panel.json`**
 

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,5 +1,91 @@
 # Release Notes
 
+## v2.13.5 — 2026-04-19 (NetworkProfile 自适应 + agent HARD-GATE 主动触发 Playwright)
+
+> **用户反馈**："我使用下来，并没有遇到模型主动使用 Playwright 的问题" · 诊断发现 agent role-play 阶段根本没教过要调 Playwright · 脚本自动跑 OK 但 agent 不补漏
+
+### 三层解决
+
+**Layer 1 · `NetworkProfile` 升级**（`lib/network_preflight.py`）
+
+从 v2.10.2 的 "5 个国内 TCP connect" 升级到：
+- **9 个目标 3 组**：国内（push2/cninfo/xueqiu）+ 境外（yahoo/coingecko/baike）+ 搜索（ddgs/baidu/github）
+- **代理检测**：扫 HTTP_PROXY/HTTPS_PROXY/ALL_PROXY 大小写 6 个 env
+- **结构化输出**：`NetworkProfile(domestic_ok, overseas_ok, search_ok, has_proxy, recommendation, severity)`
+- **缓存到 `.cache/_global/network_profile.json`** · 5min TTL · agent 介入时直接读
+
+诊断输出：
+```
+🌐 网络预检 (9/9 通 · 均延迟 4ms · proxy=no)
+  [国内 3/3] ✓ push2.eastmoney.com · cninfo · 雪球
+  [境外 3/3] ✓ query1.finance.yahoo.com · api.coingecko.com · baike.baidu.com
+  [搜索 3/3] ✓ duckduckgo.com · www.baidu.com · api.github.com
+  ✓ 全网通畅 · Playwright 可抓境内+境外所有源
+```
+
+**Layer 2 · Agent HARD-GATE-PLAYWRIGHT-AUTOFILL**（`SKILL.md` / `AGENTS.md` / `commands/analyze-stock.md`）
+
+明确要求 agent 在 stage1 → stage2 **之间**：
+
+```python
+# 1. 读网络 profile
+net = json.loads(Path(".cache/_global/network_profile.json").read_text())
+print(net["recommendation"])  # 人读的建议
+
+# 2. 读自查 issues 找低质量维度
+issues = json.loads(Path(f".cache/{ticker}/_review_issues.json").read_text())
+low_q = [i["dim"] for i in issues["issues"]
+         if i.get("category")=="data" and i.get("severity") in ("critical","warning")]
+
+# 3. 主动强制跑 Playwright 兜底
+if low_q:
+    os.environ["UZI_PLAYWRIGHT_FORCE"] = "1"
+    from lib.playwright_fallback import autofill_via_playwright
+    autofill_via_playwright(raw, ticker)
+```
+
+**绝对禁止**：看到 `data.growth = "—"` 直接在 commentary 里写"增速待补充"——应该先让 Playwright 抓一次。
+
+**Layer 3 · `DIM_STRATEGIES` 按 NetworkProfile 自适应**（`lib/playwright_fallback.py`）
+
+每个维度声明所需网络能力：
+```python
+DIM_NETWORK_REQUIREMENTS = {
+    "4_peers":       ("domestic",),              # 雪球
+    "7_industry":    ("domestic", "search"),     # 百度搜索
+    "18_trap":       ("domestic", "search"),     # 小红书搜索
+    "14_moat":       ("domestic",),              # 百度百科
+    # ... 10 个维度都声明
+}
+```
+
+运行时按 profile 过滤：
+- `search_ok=False` → 7_industry / 18_trap 直接跳（跳前打印原因）
+- `domestic_ok=False` → 10 维全跳
+- 日志明确："🌐 网络过滤 · 跳过 2 维: 7_industry(search 不通), 18_trap(search 不通)"
+
+### 回归测试
+
+- 新增 `tests/test_v2_13_5_preflight_adaptive.py` · **14 个用例**
+- NetworkProfile：proxy env / recommendation 变化 / cache 读写 / stale 重测
+- DIM_STRATEGIES 自适应：domestic 不通全跳 / search 不通部分跳 / 全通全保留
+- HARD-GATE 文档：SKILL.md / AGENTS.md / commands 都含 `autofill_via_playwright` 字面量
+- 全量 **195 passed**（v2.13.4 181 + 新 14）
+
+### 用户影响
+
+从此 agent 遇到空数据会**主动**开浏览器补：
+- v2.13.2 autofill_via_playwright 只在 stage1 末尾跑一次 · 漏补的维度 agent 没补
+- v2.13.5 agent role-play 前 **强制再跑一次 FORCE 模式** · 覆盖 stage1 漏的
+
+配合 v2.13.2 `UZI_PLAYWRIGHT_FORCE=1` + v2.13.1 全 10 维覆盖 + v2.13.0 三档分级 · 形成完整 Playwright 层。
+
+### 升级
+
+`git pull origin main` · 下次 agent 读 SKILL.md 自动按新 HARD-GATE 执行
+
+---
+
 ## v2.13.4 — 2026-04-19 (新增 10 个经 curl 验证的无 Key 公开数据源)
 
 > **用户提供 Grok 清单 20+ 个 "全网最全" 无需 Key 的行情接口** · 批量 curl 真实验证 · 过滤无效项 · 9 有效加密源 + 1 Yahoo Chart v8 + 1 腾讯港股 quote 注册入库

--- a/commands/analyze-stock.md
+++ b/commands/analyze-stock.md
@@ -24,6 +24,23 @@ python -c "from run_real_test import stage1; stage1('$ARGUMENTS')"
 
 Stage 1 跑完后，**你必须做以下事情**：
 
+**0. v2.13.5 · Playwright 兜底前置（必走）**
+
+```python
+import json, os
+from pathlib import Path
+net = json.loads(Path(".cache/_global/network_profile.json").read_text(encoding="utf-8"))
+issues = json.loads(Path(f".cache/{ticker}/_review_issues.json").read_text(encoding="utf-8"))
+low_quality_dims = [
+    i["dim"] for i in issues.get("issues", [])
+    if i.get("category") == "data" and i.get("severity") in ("critical", "warning")
+]
+if low_quality_dims:
+    os.environ["UZI_PLAYWRIGHT_FORCE"] = "1"
+    from lib.playwright_fallback import autofill_via_playwright
+    autofill_via_playwright(raw, ticker)  # 主动强制再跑一次 · 补数据
+```
+
 **1. 读取评委骨架分**
 
 读 `.cache/{ticker}/panel.json`，看 51 人各自打了多少分。特别关注：

--- a/docs/BUGS-LOG.md
+++ b/docs/BUGS-LOG.md
@@ -7,6 +7,40 @@
 
 ---
 
+## v2.13.5 (2026-04-19 · NetworkProfile 自适应 + agent HARD-GATE 主动触发 Playwright)
+
+### BUG · agent role-play 阶段不主动调 Playwright · 低质量数据未被兜底
+- **症状**：用户反馈"我使用下来，并没有遇到模型主动使用 Playwright 的问题"
+- **位置**：SKILL.md / AGENTS.md / commands/analyze-stock.md 的 agent 工作流指引
+- **根因**：
+  - stage1 末尾 `autofill_via_playwright` 自动跑一次 OK，但 data 有字段但全是 "—" 时 `_dim_needs_fallback` 判"不需要兜底" → 跳过
+  - agent 介入阶段只做 role-play，不碰数据补充
+  - SKILL.md 只在多处散句提及 "Chrome/Playwright MCP"，**没有** HARD-GATE 明确要求 agent 主动调 autofill
+- **影响**：
+  - 每次 agent role-play 出报告时，某些维度仍空
+  - 用户看到 "数据缺失" 的 commentary 模板话术
+  - Playwright 基础设施已全 · 但 agent 层**被动**不用
+- **修法**（三层）：
+  1. `lib/network_preflight.py` 升级 NetworkProfile（9 目标 3 组 + 代理检测 + 写 cache）· 提供 agent 决策输入
+  2. SKILL.md 加 `HARD-GATE-PLAYWRIGHT-AUTOFILL` · 明确 3 step 流程：读 net profile → 读 review_issues.json → 主动 FORCE 跑 autofill
+  3. `lib/playwright_fallback.DIM_NETWORK_REQUIREMENTS` 每维声明网络能力 · `_filter_dims_by_network` 自动过滤
+- **验证**：
+  - agent 按 SKILL.md 指引跑 · 看到 `_review_issues.json` warning 主动调 Playwright
+  - 测试构造 `NetworkProfile(domestic_ok=False)` → `_filter_dims_by_network` 全跳
+  - `NetworkProfile(search_ok=False)` → 7_industry / 18_trap 跳 · 其他维度保留
+- **回归测试**：`tests/test_v2_13_5_preflight_adaptive.py` 14 用例
+  - Layer 1：代理检测 / recommendation 变化 / cache 读写 / stale 重测（6 用例）
+  - Layer 3：domestic offline 全跳 / search offline 部分跳 / 全通保留（3 用例）
+  - Layer 2：SKILL.md / AGENTS.md / commands 文档检查（3 用例）
+  - 基本数据类：NetworkProfile 字段 / DIM_NETWORK_REQUIREMENTS 完整性（2 用例）
+- **若未来改 agent 工作流**：
+  - HARD-GATE-PLAYWRIGHT-AUTOFILL 不能删（SKILL.md line ~125 附近）· agent 读了就会主动用
+  - `.cache/_global/network_profile.json` schema 不能破（agent 依赖 domestic_ok/overseas_ok/search_ok 三字段）
+  - `DIM_NETWORK_REQUIREMENTS` 需覆盖 DIM_STRATEGIES 所有 key（有测试护栏 `test_dim_network_requirements_complete`）
+  - 新增维度要同步加网络声明
+
+---
+
 ## v2.13.3 (2026-04-19 · 51 评委规则全员历史立场还原)
 
 ### BUG · 19 位评委给中际旭创 100 分 · 立场与历史严重不符

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stock-deep-analyzer",
-  "version": "2.13.4",
+  "version": "2.13.5",
   "description": "A股/港股/美股个股深度分析引擎 · 22维数据 × 51位大佬量化评委 · 17种机构级分析方法 | A-share / HK / US deep-analysis · 22 dims × 51-investor jury × 17 institutional methods",
   "type": "module",
   "author": "FloatFu-true",

--- a/skills/deep-analysis/SKILL.md
+++ b/skills/deep-analysis/SKILL.md
@@ -122,6 +122,77 @@ Payload 示例（agent 看到这个就知道该走 ETF 引导流程）:
 用户要求原话："不能只靠数据爬取，必须要 agent 介入高强度分析 + 多 agent 操作一定要加入进去"
 </HARD-GATE>
 
+### ⛔ HARD-GATE-PLAYWRIGHT-AUTOFILL · agent 必须主动触发 Playwright 兜底（v2.13.5）
+
+<HARD-GATE>
+用户反馈："我使用下来，并没有遇到模型主动使用 Playwright 的问题"。
+
+v2.13.5 起 **agent 介入阶段（stage1 → stage2 之间）必须主动触发 Playwright
+兜底**，不能等脚本 stage1 末尾自动跑就算完。原因：
+
+1. Stage1 末尾的 `autofill_via_playwright` 只跑一次 · 如果那时某维度 data 非空
+   但全是 "—"，`_dim_needs_fallback` 判不需要兜底，会被跳过
+2. Agent 介入后往往知道"哪些维度不够"（自查报告里报 warning/critical）· 应该
+   主动再跑一次 Playwright · 而不是在 `dim_commentary` 里写"数据缺失，参考同业"
+   这种废话
+
+**强制流程**（agent role-play 开始前必走）：
+
+**Step A · 读网络 profile**（新 v2.13.5 · `.cache/_global/network_profile.json`）
+```python
+import json
+from pathlib import Path
+prof_path = Path(".cache/_global/network_profile.json")
+if prof_path.exists():
+    net = json.loads(prof_path.read_text(encoding="utf-8"))
+    # net["domestic_ok"] / net["overseas_ok"] / net["search_ok"]
+    # net["recommendation"] 人读的一句话建议
+    print(f"网络: {net['recommendation']}")
+```
+
+**Step B · 读自查 issues 找低质量维度**
+```python
+issues_path = Path(f".cache/{ticker}/_review_issues.json")
+issues = json.loads(issues_path.read_text())
+low_quality_dims = [
+    i["dim"] for i in issues.get("issues", [])
+    if i.get("severity") in ("critical", "warning") and i.get("category") == "data"
+]
+# 例：["4_peers", "7_industry", "8_materials"]
+```
+
+**Step C · 主动触发 Playwright 兜底**（即使 stage1 跑过也再跑一次 · 用 FORCE=1）
+```python
+import os
+os.environ["UZI_PLAYWRIGHT_FORCE"] = "1"
+from lib.playwright_fallback import autofill_via_playwright
+summary = autofill_via_playwright(raw, ticker)
+# summary: {"attempted": X, "succeeded": Y, "failed": Z, "skipped_reasons": {...}}
+```
+
+**Step D · Playwright 失败的 dim · agent 用知识 + web_search 手工补**
+
+Playwright 也抓不到的维度（比如某些需要登录的页面）· **不能**在 commentary 里
+写空话 · 应该：
+1. 调 `WebSearch` 或 `web_search_trusted` 补原始资料
+2. 调 `mx_api`（若 MX_APIKEY 已设）
+3. 最后降级到 agent 的常识 + 明确标注"基于公开信息推断，非一手"
+
+**绝对禁止**：
+- 看到 `data.growth = "—"` 直接在 dim_commentary 里写"增速待补充"
+- 忽略 `_review_issues.json` 的 warning 直接出报告
+- Playwright summary.attempted=0 但未检查 `network_profile.json` 是否能用
+
+**绕过方式**（仅 lite / CI 环境）：
+- `UZI_DEPTH=lite` · lite 模式 `playwright_mode=off` · 此 HARD-GATE 自动跳过
+- `UZI_PLAYWRIGHT_ENABLE=0` · 显式禁用（但 deep 档不建议）
+
+v2.13.5 改动：
+- `lib/network_preflight.py` 升级 NetworkProfile（国内/境外/搜索 9 目标）· 写 cache
+- `lib/playwright_fallback.DIM_NETWORK_REQUIREMENTS` 每维声明所需网络能力
+- `autofill_via_playwright` 按 profile 自动跳过网络不可达的维度
+</HARD-GATE>
+
 ### 🎯 STYLE-WEIGHTING · 按股票风格动态加权（v2.7 · 自动）
 
 stage2 自动识别股票 style（白马 / 高成长 / 周期 / 小盘投机 / 分红防御 /

--- a/skills/deep-analysis/scripts/lib/network_preflight.py
+++ b/skills/deep-analysis/scripts/lib/network_preflight.py
@@ -1,115 +1,276 @@
-"""网络预检 · v2.10.2.
+"""网络预检 + NetworkProfile · v2.13.5.
 
-在 stage1 开始前快速 ping 几个关键域名，如果代理/GFW 挂了，**立即**告诉
-用户，而不是让他等 10 分钟每个 fetcher 挨个超时。
+v2.10.2 原版只测 5 个国内 TCP connect · 无法区分"国内通 + 境外不通"等常见大陆无代理场景.
 
-**检查目标**:
-  · push2.eastmoney.com      — akshare 行情主源
-  · duckduckgo.com            — ddgs web search
-  · api.github.com            — 通用 canary (理论上不会被墙但代理可能挂)
-
-**输出**: 3 个域名的可达性 + 总体建议
+v2.13.5 升级：
+- 9 个目标分 3 组（国内 / 境外 / 搜索）
+- 检测代理 env（HTTP_PROXY / HTTPS_PROXY / ALL_PROXY / NO_PROXY）
+- 输出结构化 `NetworkProfile` 供 agent + DIM_STRATEGIES 自适应
+- 写 `.cache/_global/network_profile.json` 让 agent 介入阶段可读
 
 **使用**:
-    from lib.network_preflight import run_preflight
-    result = run_preflight()
-    if result["critical_failures"] > 2:
-        print("⚠️ 代理似乎大面积不通，建议 --depth lite 或修代理")
+    from lib.network_preflight import get_network_profile
+    prof = get_network_profile()  # 跑预检 · 返 NetworkProfile dataclass
+    if prof.overseas_ok:
+        url = "https://query1.finance.yahoo.com/..."  # 境外源 OK
+    else:
+        url = "https://xueqiu.com/..."  # 降级到国内
 """
 from __future__ import annotations
 
+import json
+import os
 import socket
 import time
-from dataclasses import dataclass
+from dataclasses import dataclass, asdict, field
+from pathlib import Path
 
 
 @dataclass
 class DomainCheck:
     domain: str
+    group: str  # "domestic" | "overseas" | "search"
     reachable: bool
     latency_ms: int
     error: str = ""
     purpose: str = ""
 
 
-_TARGETS = [
-    ("push2.eastmoney.com", "A 股行情 (akshare 主源)"),
-    ("duckduckgo.com",       "ddgs 定性查询"),
-    ("www.cninfo.com.cn",    "cninfo 行业 PE + 公告"),
-    ("stock.xueqiu.com",     "雪球数据"),
-    ("api.github.com",       "通用网络健康度"),
+# ───────────────────────────────────────────────────────────────
+# 目标清单 · 3 组 × 3 域 = 9 目标
+# ───────────────────────────────────────────────────────────────
+
+_DOMESTIC_TARGETS = [
+    ("push2.eastmoney.com", "东财 push2 · A 股行情主源"),
+    ("www.cninfo.com.cn", "巨潮 cninfo · 公告/行业 PE"),
+    ("stock.xueqiu.com", "雪球数据"),
 ]
+
+_OVERSEAS_TARGETS = [
+    ("query1.finance.yahoo.com", "Yahoo Finance · 美股数据"),
+    ("api.coingecko.com", "CoinGecko · 加密市场流动性"),
+    ("baike.baidu.com", "百度百科 · 公司词条（国内直连但海外代理可能反被拦）"),
+]
+
+_SEARCH_TARGETS = [
+    ("duckduckgo.com", "DuckDuckGo · ddgs"),
+    ("www.baidu.com", "百度搜索"),
+    ("api.github.com", "GitHub API · 通用网络健康度"),
+]
+
+_ALL_TARGETS: list[tuple[str, str, str]] = (
+    [(d, g, p) for (d, p) in _DOMESTIC_TARGETS for g in ["domestic"]]
+    + [(d, g, p) for (d, p) in _OVERSEAS_TARGETS for g in ["overseas"]]
+    + [(d, g, p) for (d, p) in _SEARCH_TARGETS for g in ["search"]]
+)
+
+
+# ───────────────────────────────────────────────────────────────
+# NetworkProfile · 结构化输出
+# ───────────────────────────────────────────────────────────────
+
+@dataclass
+class NetworkProfile:
+    """v2.13.5 · 网络情况的结构化画像 · 供 agent 和 DIM_STRATEGIES 自适应."""
+    domestic_ok: bool = False
+    overseas_ok: bool = False
+    search_ok: bool = False
+    has_proxy: bool = False  # HTTP_PROXY / HTTPS_PROXY / ALL_PROXY 任一设置
+    proxy_url: str = ""
+    domestic_count: int = 0   # 通的数量（0-3）
+    overseas_count: int = 0
+    search_count: int = 0
+    avg_latency_ms: int = 0
+    recommendation: str = ""  # 给 agent 看的一句话建议
+    severity: str = "ok"      # ok | warning | degraded | critical
+    probed_at: float = 0.0    # unix timestamp
+    checks: list = field(default_factory=list)  # List[dict] (asdict(DomainCheck))
+
+    def to_dict(self) -> dict:
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, d: dict) -> "NetworkProfile":
+        d = dict(d)
+        d.pop("checks", None)  # 读回时不反序列化明细
+        return cls(**{k: v for k, v in d.items() if k in cls.__dataclass_fields__})
 
 
 def _probe(domain: str, port: int = 443, timeout: float = 3.0) -> DomainCheck:
-    """TCP connect probe（不做 HTTP，只测底层连通）."""
     t0 = time.time()
     try:
         sock = socket.create_connection((domain, port), timeout=timeout)
         sock.close()
         return DomainCheck(
-            domain=domain,
-            reachable=True,
+            domain=domain, group="", reachable=True,
             latency_ms=int((time.time() - t0) * 1000),
         )
     except socket.gaierror as e:
-        return DomainCheck(domain=domain, reachable=False, latency_ms=int((time.time() - t0) * 1000),
+        return DomainCheck(domain=domain, group="", reachable=False,
+                           latency_ms=int((time.time() - t0) * 1000),
                            error=f"DNS fail: {e}")
     except socket.timeout:
-        return DomainCheck(domain=domain, reachable=False, latency_ms=int(timeout * 1000),
+        return DomainCheck(domain=domain, group="", reachable=False,
+                           latency_ms=int(timeout * 1000),
                            error=f"timeout > {timeout}s")
     except Exception as e:
-        return DomainCheck(domain=domain, reachable=False, latency_ms=int((time.time() - t0) * 1000),
+        return DomainCheck(domain=domain, group="", reachable=False,
+                           latency_ms=int((time.time() - t0) * 1000),
                            error=f"{type(e).__name__}: {str(e)[:80]}")
 
 
-def run_preflight(verbose: bool = True, timeout: float = 3.0) -> dict:
-    """跑一遍预检。返回诊断字典."""
+def _detect_proxy() -> tuple[bool, str]:
+    """从 env 检测代理配置 · 返 (has_proxy, proxy_url)."""
+    for var in ("HTTPS_PROXY", "HTTP_PROXY", "ALL_PROXY",
+                "https_proxy", "http_proxy", "all_proxy"):
+        v = os.environ.get(var, "").strip()
+        if v and v.lower() not in ("off", "no", "false"):
+            return True, f"{var}={v}"
+    return False, ""
+
+
+def _build_recommendation(p: NetworkProfile) -> tuple[str, str]:
+    """根据 profile 生成 agent-facing 建议文本 + severity."""
+    # severity
+    if p.domestic_count >= 2 and p.overseas_count >= 2 and p.search_count >= 2:
+        sev = "ok"
+    elif p.domestic_count >= 2 and p.search_count >= 1:
+        sev = "warning"
+    elif p.domestic_count >= 1:
+        sev = "degraded"
+    else:
+        sev = "critical"
+
+    # recommendation
+    if p.domestic_ok and p.overseas_ok and p.search_ok:
+        rec = "✓ 全网通畅 · Playwright 可抓境内+境外所有源"
+    elif p.domestic_ok and not p.overseas_ok and p.search_ok:
+        rec = (
+            "✓ 国内网络正常 · ✗ 境外受限 · "
+            "Playwright 只抓国内源（东财 F10 / cninfo / 雪球 public / 百度搜索）· "
+            "跳过 Yahoo / CoinGecko / 英文 Wikipedia"
+        )
+    elif p.domestic_ok and not p.overseas_ok and not p.search_ok:
+        rec = (
+            "⚠ 国内通 · 搜索受限 · 境外不通 · "
+            "Playwright 只抓国内无搜索依赖的源（东财 F10 / cninfo / 雪球 page）· "
+            "跳 baidu/百度搜索/Yahoo/CoinGecko"
+        )
+    elif not p.domestic_ok and p.overseas_ok:
+        rec = (
+            "⚠ 境外 VPN 环境 · 国内源受限 · "
+            "Playwright 可抓 Yahoo/CoinGecko · 但不抓东财 push2（国内限外 IP）· "
+            "建议 akshare 配合用 xueqiu fallback"
+        )
+    elif p.domestic_count >= 1:
+        rec = "⚠ 网络不稳 · 建议 --depth lite + 跳过 Playwright 省时间"
+    else:
+        rec = "🔴 网络严重不通 · 建议退出修网络 · lite 模式也会失败"
+
+    return rec, sev
+
+
+def run_preflight(verbose: bool = True, timeout: float = 3.0) -> NetworkProfile:
+    """跑预检 · 返 NetworkProfile（不同于 v2.10.2 dict）· 自动写 cache.
+
+    写入 `.cache/_global/network_profile.json` 供 agent/subagent 读。
+    """
+    has_proxy, proxy_url = _detect_proxy()
+
     results: list[DomainCheck] = []
-    for domain, purpose in _TARGETS:
+    for domain, group, purpose in _ALL_TARGETS:
         r = _probe(domain, timeout=timeout)
+        r.group = group
         r.purpose = purpose
         results.append(r)
 
-    reachable = sum(1 for r in results if r.reachable)
-    failures = len(results) - reachable
-    avg_latency = sum(r.latency_ms for r in results if r.reachable) / max(reachable, 1)
+    dom_ok = sum(1 for r in results if r.group == "domestic" and r.reachable)
+    ovs_ok = sum(1 for r in results if r.group == "overseas" and r.reachable)
+    sch_ok = sum(1 for r in results if r.group == "search" and r.reachable)
 
-    # 决策
-    if failures == 0:
-        advisory = "✓ 网络畅通"
-        severity = "ok"
-    elif failures == 1:
-        advisory = "⚠ 单点不通，整体可跑（可能个别 fetcher 降级）"
-        severity = "warning"
-    elif failures == 2:
-        advisory = "⚠⚠ 多点不通，建议 --depth lite 节省时间"
-        severity = "degraded"
-    else:
-        advisory = "🔴 代理/网络严重不通，强烈建议先修网络或用 --depth lite"
-        severity = "critical"
+    avg_lat = 0
+    reachable_latencies = [r.latency_ms for r in results if r.reachable]
+    if reachable_latencies:
+        avg_lat = int(sum(reachable_latencies) / len(reachable_latencies))
+
+    prof = NetworkProfile(
+        domestic_ok=dom_ok >= 2,        # 3 个有 2 个通算 ok
+        overseas_ok=ovs_ok >= 2,
+        search_ok=sch_ok >= 2,
+        has_proxy=has_proxy,
+        proxy_url=proxy_url,
+        domestic_count=dom_ok,
+        overseas_count=ovs_ok,
+        search_count=sch_ok,
+        avg_latency_ms=avg_lat,
+        probed_at=time.time(),
+        checks=[asdict(r) for r in results],
+    )
+    prof.recommendation, prof.severity = _build_recommendation(prof)
 
     if verbose:
-        print(f"\n🌐 网络预检 ({reachable}/{len(results)} 通 · 均延迟 {avg_latency:.0f}ms)")
-        for r in results:
-            mark = f"✓ {r.latency_ms:4d}ms" if r.reachable else f"✗ {r.error[:40]}"
-            print(f"  {mark}  {r.domain:28} · {r.purpose}")
-        print(f"\n  {advisory}\n")
+        total = len(results)
+        reachable_count = sum(1 for r in results if r.reachable)
+        print(f"\n🌐 网络预检 ({reachable_count}/{total} 通 · 均延迟 {avg_lat}ms · "
+              f"proxy={'yes' if has_proxy else 'no'})")
+        groups = [("国内", "domestic"), ("境外", "overseas"), ("搜索", "search")]
+        for label, g in groups:
+            grp = [r for r in results if r.group == g]
+            grp_ok = sum(1 for r in grp if r.reachable)
+            print(f"  [{label} {grp_ok}/{len(grp)}]")
+            for r in grp:
+                mark = f"✓ {r.latency_ms:4d}ms" if r.reachable else f"✗ {r.error[:35]}"
+                print(f"    {mark}  {r.domain:32} · {r.purpose}")
+        print(f"\n  {prof.recommendation}\n")
 
+    # 写 cache 供 agent 介入时读
+    try:
+        cache_dir = Path(__file__).resolve().parent.parent / ".cache" / "_global"
+        cache_dir.mkdir(parents=True, exist_ok=True)
+        (cache_dir / "network_profile.json").write_text(
+            json.dumps(prof.to_dict(), ensure_ascii=False, indent=2),
+            encoding="utf-8",
+        )
+    except Exception:
+        pass  # 写失败不阻塞主流程
+
+    return prof
+
+
+def get_network_profile(max_age_sec: int = 300) -> NetworkProfile:
+    """读 cache · 若过期（>5min）重跑预检.
+
+    agent 介入时调用此函数快速拿 profile · 不重跑网络测试。
+    """
+    try:
+        cache_dir = Path(__file__).resolve().parent.parent / ".cache" / "_global"
+        cache_file = cache_dir / "network_profile.json"
+        if cache_file.exists():
+            data = json.loads(cache_file.read_text(encoding="utf-8"))
+            probed_at = data.get("probed_at", 0)
+            if time.time() - probed_at < max_age_sec:
+                return NetworkProfile.from_dict(data)
+    except Exception:
+        pass
+    # 过期或不存在 · 重跑
+    return run_preflight(verbose=False)
+
+
+# v2.10.2 向后兼容 · 保留 run_preflight 返 dict 的调用者
+def run_preflight_legacy_dict(verbose: bool = True, timeout: float = 3.0) -> dict:
+    """兼容 v2.10.2 的 dict 返回格式."""
+    prof = run_preflight(verbose=verbose, timeout=timeout)
     return {
-        "reachable": reachable,
-        "failures": failures,
-        "critical_failures": failures,  # alias
-        "avg_latency_ms": int(avg_latency),
-        "advisory": advisory,
-        "severity": severity,
-        "results": [
-            {"domain": r.domain, "reachable": r.reachable, "latency_ms": r.latency_ms,
-             "error": r.error, "purpose": r.purpose}
-            for r in results
-        ],
+        "reachable": prof.domestic_count + prof.overseas_count + prof.search_count,
+        "failures": 9 - (prof.domestic_count + prof.overseas_count + prof.search_count),
+        "critical_failures": 9 - (prof.domestic_count + prof.overseas_count + prof.search_count),
+        "avg_latency_ms": prof.avg_latency_ms,
+        "advisory": prof.recommendation,
+        "severity": prof.severity,
+        "results": prof.checks,
     }
 
 
 if __name__ == "__main__":
-    run_preflight(verbose=True)
+    prof = run_preflight(verbose=True)
+    print(f"\n[JSON summary]\n{json.dumps(prof.to_dict(), ensure_ascii=False, indent=2)[:800]}")

--- a/skills/deep-analysis/scripts/lib/playwright_fallback.py
+++ b/skills/deep-analysis/scripts/lib/playwright_fallback.py
@@ -470,6 +470,59 @@ DIM_STRATEGIES: dict[str, Callable] = {
 }
 
 
+# v2.13.5 · 维度 → 所需网络能力（用于 NetworkProfile 自适应过滤）
+# domestic: 需要国内源通（东财/cninfo/雪球）
+# search: 需要搜索引擎通（百度/ddgs）
+# overseas: 需要境外源通（Yahoo/CoinGecko/Wikipedia EN）
+DIM_NETWORK_REQUIREMENTS: dict[str, tuple[str, ...]] = {
+    "4_peers":       ("domestic",),              # 雪球 /S/{sym}
+    "8_materials":   ("domestic",),              # 东财 F10
+    "15_events":     ("domestic",),              # cninfo 公告
+    "17_sentiment":  ("domestic",),              # 雪球 /POST
+    "3_macro":       ("domestic",),              # stats.gov.cn
+    "7_industry":    ("domestic", "search"),     # 百度搜索行业景气度
+    "14_moat":       ("domestic",),              # 百度百科
+    "13_policy":     ("domestic",),              # csrc.gov.cn
+    "18_trap":       ("domestic", "search"),     # 小红书搜索页（需搜索）
+    "19_contests":   ("domestic",),              # 雪球 /cube/rank/list
+}
+
+
+def _filter_dims_by_network(dims: frozenset) -> tuple[frozenset, list[str]]:
+    """v2.13.5 · 按当前 NetworkProfile 过滤白名单 · 返 (有效维度, 被跳维度清单).
+
+    例：国内网络不通 → 所有 domestic 维度全跳
+    例：搜索不通 → 7_industry / 18_trap 跳
+    """
+    try:
+        from lib.network_preflight import get_network_profile
+        net = get_network_profile()
+    except Exception:
+        return dims, []  # 拿不到 profile · 不过滤
+
+    effective = set()
+    skipped: list[str] = []
+    for d in dims:
+        reqs = DIM_NETWORK_REQUIREMENTS.get(d, ())
+        satisfied = True
+        why = []
+        for req in reqs:
+            if req == "domestic" and not net.domestic_ok:
+                satisfied = False
+                why.append("domestic 不通")
+            elif req == "search" and not net.search_ok:
+                satisfied = False
+                why.append("search 不通")
+            elif req == "overseas" and not net.overseas_ok:
+                satisfied = False
+                why.append("overseas 不通")
+        if satisfied:
+            effective.add(d)
+        else:
+            skipped.append(f"{d}({','.join(why)})")
+    return frozenset(effective), skipped
+
+
 # ─── 入口 · post-fetch 兜底 ──────────────────────────────────────
 
 def _is_empty_value(v) -> bool:
@@ -577,12 +630,21 @@ def autofill_via_playwright(raw: dict, ticker: str) -> dict:
     dims = raw.get("dimensions", {})
     force = os.environ.get("UZI_PLAYWRIGHT_FORCE") == "1"
 
+    # v2.13.5 · NetworkProfile 自适应 · 无网络能力的维度直接跳过不尝试
+    effective_dims, network_skipped = _filter_dims_by_network(profile.playwright_dims)
+    if network_skipped:
+        print(f"   🌐 网络过滤 · 跳过 {len(network_skipped)} 维: {', '.join(network_skipped)}")
+        for s in network_skipped:
+            dim_name = s.split("(")[0]
+            summary["skipped"] += 1
+            summary["skip_reasons"][dim_name] = f"网络能力不足 · {s}"
+
     print(f"   🎭 profile={profile.depth} · playwright_dims={len(profile.playwright_dims)}"
-          f" · FORCE={force}")
+          f" · effective={len(effective_dims)} · FORCE={force}")
 
     from lib.junk_filter import is_junk_autofill_text
 
-    for dim_key in sorted(profile.playwright_dims):
+    for dim_key in sorted(effective_dims):
         dim = dims.get(dim_key, {})
 
         if not force:

--- a/skills/deep-analysis/scripts/run_real_test.py
+++ b/skills/deep-analysis/scripts/run_real_test.py
@@ -1546,10 +1546,11 @@ def stage1(ticker: str) -> dict:
         try:
             from lib.network_preflight import run_preflight
             pre = run_preflight(verbose=True, timeout=3.0)
-            # 3 个以上不通 → 强制 lite
-            if pre["critical_failures"] >= 3 and os.environ.get("UZI_LITE") != "0":
+            # v2.13.5 · NetworkProfile 返 dataclass · 用 severity 判定
+            # critical/degraded → 强制 lite（除非 UZI_LITE=0 显式覆盖）
+            if pre.severity in ("critical", "degraded") and os.environ.get("UZI_LITE") != "0":
                 os.environ["UZI_LITE"] = "1"
-                print(f"   ⚡ 网络严重受限，自动切 lite 模式防止挂太久\n")
+                print(f"   ⚡ 网络受限（{pre.severity}），自动切 lite 模式防止挂太久\n")
         except Exception as _e:
             print(f"  ⚠️ preflight failed (非致命): {_e}")
 

--- a/skills/deep-analysis/scripts/tests/test_v2_13_5_preflight_adaptive.py
+++ b/skills/deep-analysis/scripts/tests/test_v2_13_5_preflight_adaptive.py
@@ -1,0 +1,238 @@
+"""Regression tests for v2.13.5 · NetworkProfile + 自适应 DIM_STRATEGIES + agent HARD-GATE.
+
+三层验证：
+1. NetworkProfile 9 目标 3 组 + 代理检测 + 缓存
+2. DIM_STRATEGIES 按 network 自适应过滤
+3. SKILL.md + AGENTS.md 含 HARD-GATE-PLAYWRIGHT-AUTOFILL
+"""
+from __future__ import annotations
+
+import importlib
+import json
+import os
+import sys
+import time
+from pathlib import Path
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+SCRIPTS = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(SCRIPTS))
+
+
+def _reset_env():
+    for k in ("HTTP_PROXY", "HTTPS_PROXY", "ALL_PROXY", "http_proxy",
+              "https_proxy", "all_proxy", "UZI_PLAYWRIGHT_ENABLE",
+              "UZI_PLAYWRIGHT_FORCE", "UZI_DEPTH"):
+        os.environ.pop(k, None)
+
+
+# ─── Layer 1 · NetworkProfile ─────────────────────────────────────
+
+def test_network_profile_dataclass_exists():
+    from lib.network_preflight import NetworkProfile
+    assert hasattr(NetworkProfile, "domestic_ok")
+    assert hasattr(NetworkProfile, "overseas_ok")
+    assert hasattr(NetworkProfile, "search_ok")
+    assert hasattr(NetworkProfile, "has_proxy")
+    assert hasattr(NetworkProfile, "recommendation")
+
+
+def test_detect_proxy_from_env():
+    from lib.network_preflight import _detect_proxy
+    _reset_env()
+    has, url = _detect_proxy()
+    assert has is False
+    assert url == ""
+
+    os.environ["HTTPS_PROXY"] = "http://127.0.0.1:7890"
+    has, url = _detect_proxy()
+    assert has is True
+    assert "7890" in url
+    _reset_env()
+
+
+def test_detect_proxy_ignores_lowercase_off():
+    from lib.network_preflight import _detect_proxy
+    _reset_env()
+    os.environ["http_proxy"] = "off"
+    has, _ = _detect_proxy()
+    assert has is False
+    _reset_env()
+
+
+def test_run_preflight_writes_cache_json():
+    from lib.network_preflight import run_preflight
+    _reset_env()
+    # mock _probe so network tests don't hit real net
+    from lib import network_preflight as np
+
+    def fake_probe(domain, port=443, timeout=3.0):
+        return np.DomainCheck(domain=domain, group="", reachable=True, latency_ms=5)
+
+    with patch.object(np, "_probe", side_effect=fake_probe):
+        prof = run_preflight(verbose=False)
+
+    assert prof.domestic_ok
+    assert prof.overseas_ok
+    assert prof.search_ok
+    cache = SCRIPTS / ".cache" / "_global" / "network_profile.json"
+    assert cache.exists()
+    data = json.loads(cache.read_text(encoding="utf-8"))
+    assert data["severity"] in ("ok", "warning", "degraded", "critical")
+    assert "recommendation" in data
+
+
+def test_recommendation_varies_by_profile():
+    from lib.network_preflight import NetworkProfile, _build_recommendation
+    # 国内通 + 境外受限 · 典型大陆无代理
+    p = NetworkProfile(
+        domestic_ok=True, overseas_ok=False, search_ok=True,
+        domestic_count=3, overseas_count=0, search_count=2,
+    )
+    rec, sev = _build_recommendation(p)
+    assert "国内" in rec and "境外" in rec
+    assert "Playwright" in rec
+
+    # 全通
+    p2 = NetworkProfile(domestic_ok=True, overseas_ok=True, search_ok=True,
+                        domestic_count=3, overseas_count=3, search_count=3)
+    rec2, sev2 = _build_recommendation(p2)
+    assert sev2 == "ok"
+
+    # 全不通
+    p3 = NetworkProfile(domestic_ok=False, overseas_ok=False, search_ok=False,
+                        domestic_count=0, overseas_count=0, search_count=0)
+    rec3, sev3 = _build_recommendation(p3)
+    assert sev3 == "critical"
+
+
+def test_get_network_profile_uses_cache():
+    from lib import network_preflight as np
+    # 手写一个 fresh profile 到 cache
+    cache = SCRIPTS / ".cache" / "_global" / "network_profile.json"
+    cache.parent.mkdir(parents=True, exist_ok=True)
+    fresh_data = {
+        "domestic_ok": True, "overseas_ok": False, "search_ok": True,
+        "has_proxy": False, "proxy_url": "",
+        "domestic_count": 3, "overseas_count": 0, "search_count": 2,
+        "avg_latency_ms": 10,
+        "probed_at": time.time(),  # fresh
+        "severity": "warning", "recommendation": "stale test",
+    }
+    cache.write_text(json.dumps(fresh_data), encoding="utf-8")
+
+    # Mock _probe so we can detect if run_preflight re-runs
+    probe_called = {"flag": False}
+    def fake_probe(*a, **k):
+        probe_called["flag"] = True
+        return np.DomainCheck(domain="x", group="", reachable=True, latency_ms=1)
+
+    with patch.object(np, "_probe", side_effect=fake_probe):
+        prof = np.get_network_profile(max_age_sec=3600)
+
+    assert prof.recommendation == "stale test"  # 从 cache 读
+    assert probe_called["flag"] is False  # 没触发 re-probe
+
+
+def test_get_network_profile_reprobes_when_stale():
+    from lib import network_preflight as np
+    cache = SCRIPTS / ".cache" / "_global" / "network_profile.json"
+    stale_data = {
+        "domestic_ok": False, "probed_at": time.time() - 99999,  # 过期
+    }
+    cache.parent.mkdir(parents=True, exist_ok=True)
+    cache.write_text(json.dumps(stale_data), encoding="utf-8")
+
+    probe_called = {"count": 0}
+    def fake_probe(*a, **k):
+        probe_called["count"] += 1
+        return np.DomainCheck(domain="x", group="", reachable=True, latency_ms=1)
+
+    with patch.object(np, "_probe", side_effect=fake_probe):
+        np.get_network_profile(max_age_sec=60)
+
+    assert probe_called["count"] > 0  # 触发了 re-probe
+
+
+# ─── Layer 3 · DIM_STRATEGIES 自适应 ──────────────────────────────
+
+def test_dim_network_requirements_complete():
+    """10 个维度都应在 DIM_NETWORK_REQUIREMENTS 里."""
+    from lib.playwright_fallback import DIM_STRATEGIES, DIM_NETWORK_REQUIREMENTS
+    for dim in DIM_STRATEGIES.keys():
+        assert dim in DIM_NETWORK_REQUIREMENTS, f"{dim} 缺网络需求声明"
+
+
+def test_filter_dims_by_network_drops_domestic_when_offline():
+    from lib import playwright_fallback as pf
+    from lib.network_preflight import NetworkProfile
+
+    fake_profile = NetworkProfile(
+        domestic_ok=False, overseas_ok=True, search_ok=True,
+        domestic_count=0, overseas_count=3, search_count=3,
+    )
+    with patch("lib.network_preflight.get_network_profile", return_value=fake_profile):
+        dims = frozenset({"4_peers", "7_industry", "8_materials"})
+        eff, skipped = pf._filter_dims_by_network(dims)
+    assert len(eff) == 0, "域不通时所有 domestic 维度都应跳"
+    assert len(skipped) == 3
+
+
+def test_filter_dims_by_network_drops_search_when_search_offline():
+    from lib import playwright_fallback as pf
+    from lib.network_preflight import NetworkProfile
+
+    fake_profile = NetworkProfile(
+        domestic_ok=True, overseas_ok=False, search_ok=False,
+        domestic_count=3, overseas_count=0, search_count=0,
+    )
+    with patch("lib.network_preflight.get_network_profile", return_value=fake_profile):
+        dims = frozenset({"4_peers", "7_industry", "18_trap"})
+        eff, skipped = pf._filter_dims_by_network(dims)
+    # 4_peers 仅需 domestic · 保留
+    assert "4_peers" in eff
+    # 7_industry / 18_trap 需 search · 跳
+    assert "7_industry" not in eff
+    assert "18_trap" not in eff
+
+
+def test_filter_dims_keeps_all_when_network_ok():
+    from lib import playwright_fallback as pf
+    from lib.network_preflight import NetworkProfile
+
+    fake_profile = NetworkProfile(
+        domestic_ok=True, overseas_ok=True, search_ok=True,
+        domestic_count=3, overseas_count=3, search_count=3,
+    )
+    with patch("lib.network_preflight.get_network_profile", return_value=fake_profile):
+        dims = frozenset({"4_peers", "7_industry", "18_trap", "14_moat"})
+        eff, skipped = pf._filter_dims_by_network(dims)
+    assert eff == dims
+    assert skipped == []
+
+
+# ─── Layer 2 · HARD-GATE 文档检查 ────────────────────────────────
+
+def test_skill_md_has_playwright_autofill_gate():
+    skill = Path(SCRIPTS).parent / "SKILL.md"
+    txt = skill.read_text(encoding="utf-8")
+    assert "HARD-GATE-PLAYWRIGHT-AUTOFILL" in txt
+    assert "autofill_via_playwright" in txt
+    assert "UZI_PLAYWRIGHT_FORCE" in txt
+    assert "network_profile.json" in txt
+
+
+def test_agents_md_has_playwright_prefetch_step():
+    agents = Path(SCRIPTS).parent.parent.parent / "AGENTS.md"
+    txt = agents.read_text(encoding="utf-8")
+    assert "Playwright 兜底前置" in txt or "autofill_via_playwright" in txt
+    assert "_review_issues.json" in txt
+
+
+def test_analyze_stock_command_has_prefetch():
+    cmd = Path(SCRIPTS).parent.parent.parent / "commands" / "analyze-stock.md"
+    txt = cmd.read_text(encoding="utf-8")
+    assert "autofill_via_playwright" in txt
+    assert "UZI_PLAYWRIGHT_FORCE" in txt


### PR DESCRIPTION
## Summary

用户反馈"没遇到模型主动用 Playwright" · 诊断三层原因 · 一次性修完

### 3 Layer

1. **NetworkProfile 升级** · 9 目标 3 组 + 代理检测 + 写 cache 供 agent 读
2. **HARD-GATE-PLAYWRIGHT-AUTOFILL** · SKILL.md + AGENTS.md + commands 明确要求 agent 主动 FORCE 跑 autofill
3. **DIM_STRATEGIES 按 NetworkProfile 自适应** · search 不通时 7_industry/18_trap 跳 · domestic 不通全跳

### Test plan

- [x] pytest 195 passed（v2.13.4 181 + 新 14）
- [x] 本地真跑 preflight 输出 9/9 通
- [x] 代理 env 检测 · proxy_url 正确解析

🤖 Generated with [Claude Code](https://claude.com/claude-code)