### PR TITLE
v2.15.2: GitHub issue #36 + #30 hotfix

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "stock-deep-analyzer",
-  "version": "2.15.1",
+  "version": "2.15.2",
   "description": "A股/港股/美股个股深度分析引擎 · 22维数据 × 51位大佬量化评委 × 17种机构级分析方法 · 杀猪盘检测 · Bloomberg风格HTML报告 | A-share / HK / US stock deep-analysis with first-class Chinese-market coverage — 22 data dims × 51-investor jury × 17 institutional methods · trap detection · Bloomberg-style HTML report",
   "author": {
     "name": "FloatFu-true",

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "stock-deep-analyzer",
   "description": "A股/港股/美股个股深度分析引擎 · 22维数据 × 51位大佬量化评委 · 17种机构级分析方法 | A-share / HK / US deep-analysis · 22 dims × 51-investor jury × 17 institutional methods",
-  "version": "2.15.1",
+  "version": "2.15.2",
   "author": {
     "name": "FloatFu-true"
   },

--- a/.version-bump.json
+++ b/.version-bump.json
@@ -1,9 +1,10 @@
 {
-  "version": "2.15.1",
+  "version": "2.15.2",
   "files": [
     ".claude-plugin/plugin.json",
     ".cursor-plugin/plugin.json",
     "package.json",
+    "gemini-extension.json",
     "hooks/hooks.json",
     "run.py"
   ],
@@ -11,6 +12,7 @@
     ".claude-plugin/plugin.json": "\"version\": \"VERSION\"",
     ".cursor-plugin/plugin.json": "\"version\": \"VERSION\"",
     "package.json": "\"version\": \"VERSION\"",
+    "gemini-extension.json": "\"version\": \"VERSION\"",
     "hooks/hooks.json": "Skills vVERSION_SHORT 已加载",
     "run.py": "Skills vVERSION_SHORT · 深度分析引擎"
   }

--- a/README.md
+++ b/README.md
@@ -649,6 +649,7 @@ python run.py <ticker> --no-resume
 
 | 版本 | 日期 | 主要变化 |
 |---|---|---|
+| **v2.15.2** | 2026-04-21 | **GitHub issue hotfix**：#36 Gemini CLI 安装报错（gemini-extension.json 加 version + 纳入 version-bump）· #30 网络自检增强（Clash 本地代理端口侦测 + 数据源分组诊断 + 多行修复建议 · 写进 `.cache/_global/network_profile.json` 供 agent 读）· 10 专项测试 |
 | **v2.15.1** | 2026-04-20 | **报告质量 2 bug hotfix**（实测 300470 发现）· Bug 1: fund-card 一堆 "5Y +0.0%" 假数据 · 修 `_build_row_full` + `render_fund_managers` 让 lite 行降级 · Bug 2: 14_moat 护城河被贵州茅台数据污染（DDGS 对生僻公司返超级股票结果）· 加 `_SUPERSTAR_POLLUTERS` 过滤 · 11 专项测试 |
 | **v2.15.0** | 2026-04-20 | **YAML persona 接入 agent role-play**（借鉴 augur · 取长补短）：新增 `personas/` 目录 51 个 YAML 文件（12 flagship 手写 + 39 stub 自动生成）· `lib/personas.py` 加载 + prefix-stable system message（prompt cache 省 50-90%）· `lib/i18n.py` zh/en 语言开关 · `HARD-GATE-PERSONA-ROLEPLAY` 强制 agent 读 YAML · 双盲测试（3 股 × 5 投资者）显示 YAML 14/15 vs Rules 8/15 方向准确率 · 修复 Rules 4 类"历史立场错位"硬伤 · 14 专项测试 |
 | **v2.14.0** | 2026-04-20 | **自动检测 GitHub 新版本**：每次启动 CLI 或 agent 会话，插件会检测 GitHub latest release · 有更新则弹 `y / s / n` 三选一（是 / 跳过本版 / 否）· 跳过本版后直到下一版才再弹 · 6h 缓存防 API 限流 · 非 TTY / `UZI_NO_UPDATE_CHECK=1` / 网络异常 silent skip 不阻塞 · `HARD-GATE-UPDATE-PROMPT` 让 agent 主动展示 · 13 专项测试 |

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,5 +1,85 @@
 # Release Notes
 
+## v2.15.2 — 2026-04-21 (Gemini CLI 安装修复 + 网络自检增强)
+
+> **Issue 驱动** · 处理 GitHub 社区反馈：
+> - **#36** · Veitkwok 报告 Gemini CLI 安装失败
+> - **#30** · 3150214587 希望代理 / 数据源自检修复机制
+
+### Bug 1 · Gemini CLI 安装报错（#36）
+
+**症状**：`gemini extensions install https://github.com/wbh604/UZI-Skill` 失败，报 `missing "version"`。
+
+**根因**：`gemini-extension.json` 缺 `version` 字段 · Gemini CLI 硬校验。
+
+**修复**：
+- `gemini-extension.json` 加 `"version": "2.15.2"`
+- `.version-bump.json::files` 新增 `gemini-extension.json` · 未来 bump 自动同步（避免再漏）
+
+### Feature 2 · 网络自检增强（#30）
+
+**需求**：用户通过 Clash 等代理时 · 环境偶尔不稳 · 希望 plugin 能自动诊断 + 给出修复建议。
+
+**实现**（`lib/network_preflight.py`）：
+1. **本地代理端口检测**（`_detect_local_proxy`）
+   - 扫 6 个常见端口：Clash 7890/7891/7897 · V2rayN 10808 · Shadowsocks 1080 · Charles 8888
+   - 若检到本地代理但 `HTTPS_PROXY` 未设 → 提示具体 export 命令
+   - 若 `HTTPS_PROXY` 已设但代理没启 → 提示 unset
+2. **数据源分组诊断**（`diagnose_source`）
+   - 按 3 组（domestic / overseas / search）独立汇报
+   - 每组列出受影响的具体 fetcher（如 "overseas 挂 · 影响 yfinance / _yahoo_v8_chart / CoinGecko"）
+   - 每组带多行 `fix` 建议（"检查 Clash 规则 / 切全局模式 / unset 代理"）
+3. **NetworkProfile 新增字段**
+   - `local_proxy: dict` · 本地端口检测结果
+   - `diagnostics: list` · 分组诊断列表
+4. **verbose 模式输出**
+   - 旧：一行 recommendation
+   - 新：recommendation + Clash hint + 每组诊断 + 每组 fix（多行）
+5. **cache 写入** · `.cache/_global/network_profile.json` 含 `local_proxy` + `diagnostics` · agent/sub-agent 可读取
+
+### 效果
+
+```
+🌐 网络预检 (3/9 通 · 均延迟 15ms · proxy=no)
+  [国内 2/3]
+    ✓  10ms  push2.eastmoney.com ...
+    ✗ ConnectionRefusedError  stock.xueqiu.com ...
+  [境外 0/3] ...
+
+  ⚠ 检测到本地代理运行（Clash Verge）但 env 未设 HTTPS_PROXY · 脚本默认不走代理
+     export HTTPS_PROXY=http://127.0.0.1:7897 && export HTTP_PROXY=http://127.0.0.1:7897
+
+  🔧 数据源诊断（2 组受影响）
+     [overseas] 🔴 不通 · 影响 3 个 fetcher
+       主要问题：Yahoo / CoinGecko 挂 · 美股港股数据降级
+       1. 浏览器测试 finance.yahoo.com 能否访问
+       2. 开 Clash 全局模式 ...
+     [search] 🔴 不通 · 影响 5 个 fetcher
+       ...
+```
+
+### 测试
+
+`tests/test_v2_15_2_network_enhance.py` · **10 case**：
+- `gemini-extension.json` 含 version 字段
+- `.version-bump.json` 纳入 gemini manifest
+- 本地代理端口检测（含 mock Clash 场景）
+- 分组诊断 3 态（全挂 / 全通 / 部分）
+- NetworkProfile 新字段存在
+- run_preflight 写 cache 含 `diagnostics` + `local_proxy`
+
+pytest 全量 **265 passed**（255 baseline + 10 新 · 零回归）。
+
+### 版本
+
+- `2.15.1 → 2.15.2`（patch · issue hotfix + 网络 UX 增强）
+- **5 manifest 同步**（新增 gemini-extension.json）
+- Branch: `feature/v2.15.2-gemini-network-fix`
+- Tag: `v2.15.2`
+- Close GitHub issues: **#36 · #30**
+
+---
+
 ## v2.15.1 — 2026-04-20 (报告质量 2 bug hotfix · 实测 300470 发现)
 
 > 用户用 v2.15.0 实测 300470.SZ（中密控股）· 指出报告里 2 个长期存在的视觉/准确性 bug · 本次 hotfix。

--- a/docs/BUGS-LOG.md
+++ b/docs/BUGS-LOG.md
@@ -7,6 +7,31 @@
 
 ---
 
+## v2.15.2 (2026-04-21 · GitHub issue #36 + #30 hotfix)
+
+### BUG · Gemini CLI 安装报错（#36）
+- **症状**：`gemini extensions install ...` 失败 · 报 `missing "version"`
+- **位置**：`gemini-extension.json`（仓库根目录）
+- **根因**：Gemini CLI 硬校验 `version` 字段 · 我们没给
+- **修法**：加 `"version": "2.15.2"` · 并把该文件纳入 `.version-bump.json::files` · 未来 bump 会自动同步
+- **未来注意**：每次 bump version 时确认 `gemini-extension.json` 也被更新 · 否则 Gemini CLI 用户会装到过期版本
+
+### FEATURE · 网络自检增强（#30）
+- **需求**：Clash 用户偶尔代理配错 · 希望 plugin 能诊断 + 给具体修复建议
+- **位置**：`lib/network_preflight.py`
+- **实现**：
+  1. `_detect_local_proxy()` · 扫常见代理端口（7890/7891/7897/10808/1080/8888）· 检到本地代理但 env 没 HTTPS_PROXY → 给 export 建议
+  2. `diagnose_source(profile)` · 按 domestic/overseas/search 3 组独立诊断 · 每组列 affected_fetchers + multi-line fix
+  3. `NetworkProfile` 新增 `local_proxy: dict` + `diagnostics: list` 字段
+  4. `run_preflight` 写 cache 时把这两个新字段一起落盘 · agent 可读
+  5. verbose 模式输出 · Clash hint + 每组 fix 多行
+- **未来注意**：
+  - 若加新代理工具（如 Quantumult X / Surge 一键），在 `_LOCAL_PROXY_PORTS` 里加新端口
+  - `diagnose_source` 里的 `affected_fetchers` 列表要跟实际 fetcher 保持同步（加新 fetcher 时检查）
+  - cache 文件 schema 变了 · 老 cache 读回要用 `NetworkProfile.from_dict` 的容错逻辑
+
+---
+
 ## v2.15.1 (2026-04-20 · 报告质量 2 bug hotfix · 实测 300470 发现)
 
 ### BUG 1 · fund-card 渲染 0.0% 假数据

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,5 +1,6 @@
 {
   "name": "stock-deep-analyzer",
+  "version": "2.15.2",
   "description": "A股/港股/美股个股深度分析 · 22维数据 × 51位大佬评委 × 17种机构方法 · Bloomberg风格报告",
   "contextFileName": "GEMINI.md"
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stock-deep-analyzer",
-  "version": "2.15.1",
+  "version": "2.15.2",
   "description": "A股/港股/美股个股深度分析引擎 · 22维数据 × 51位大佬量化评委 · 17种机构级分析方法 | A-share / HK / US deep-analysis · 22 dims × 51-investor jury × 17 institutional methods",
   "type": "module",
   "author": "FloatFu-true",

--- a/skills/deep-analysis/scripts/lib/network_preflight.py
+++ b/skills/deep-analysis/scripts/lib/network_preflight.py
@@ -85,6 +85,9 @@ class NetworkProfile:
     severity: str = "ok"      # ok | warning | degraded | critical
     probed_at: float = 0.0    # unix timestamp
     checks: list = field(default_factory=list)  # List[dict] (asdict(DomainCheck))
+    # v2.15.2 (#30) · 更细的自检信息
+    local_proxy: dict = field(default_factory=dict)  # {has_local_proxy, detected, hint}
+    diagnostics: list = field(default_factory=list)  # [{group, status, affected_fetchers, fix}]
 
     def to_dict(self) -> dict:
         return asdict(self)
@@ -127,6 +130,121 @@ def _detect_proxy() -> tuple[bool, str]:
         if v and v.lower() not in ("off", "no", "false"):
             return True, f"{var}={v}"
     return False, ""
+
+
+# v2.15.2 (#30) · 本地代理端口检测
+# Clash 默认端口 7890 · Clash Verge 7897 · V2rayN 10808 · Shadowsocks 1080
+_LOCAL_PROXY_PORTS = [
+    (7890, "Clash (HTTP)"),
+    (7891, "Clash (SOCKS)"),
+    (7897, "Clash Verge"),
+    (10808, "V2rayN"),
+    (1080, "Shadowsocks / SOCKS5 通用"),
+    (8888, "Charles / Fiddler"),
+]
+
+
+def _detect_local_proxy() -> dict:
+    """检测本机常见代理端口是否开启 · 无 env 但开了 Clash 的用户也能被侦测到.
+
+    返回 {
+        "has_local_proxy": bool,
+        "detected": [{"port": 7890, "name": "Clash"}, ...],
+        "hint": "Clash 已开但未设 HTTPS_PROXY · ...",
+    }
+    """
+    detected = []
+    for port, name in _LOCAL_PROXY_PORTS:
+        try:
+            sock = socket.create_connection(("127.0.0.1", port), timeout=0.3)
+            sock.close()
+            detected.append({"port": port, "name": name})
+        except (socket.timeout, ConnectionRefusedError, OSError):
+            continue
+
+    has_env_proxy, _ = _detect_proxy()
+    hint = ""
+    if detected and not has_env_proxy:
+        names = ", ".join(d["name"] for d in detected)
+        hint = (
+            f"⚠ 检测到本地代理运行（{names}）但 env 未设 HTTPS_PROXY · "
+            f"脚本默认不走代理 · 若海外源不通请：\n"
+            f"   export HTTPS_PROXY=http://127.0.0.1:{detected[0]['port']} && export HTTP_PROXY=http://127.0.0.1:{detected[0]['port']}"
+        )
+    elif not detected and has_env_proxy:
+        hint = "⚠ HTTPS_PROXY 已设但本地代理端口未响应 · 代理可能没启动 · unset 后重试"
+
+    return {
+        "has_local_proxy": bool(detected),
+        "detected": detected,
+        "hint": hint,
+    }
+
+
+def diagnose_source(profile: "NetworkProfile") -> list[dict]:
+    """v2.15.2 (#30) · 按数据源分组给出诊断 + 修复建议.
+
+    返回 list[{group, status, affected_fetchers, fix}] ·
+    比单一 recommendation 文本更精细 · 每组 ("domestic"/"overseas"/"search") 一条.
+    """
+    diagnostics = []
+
+    # Domestic 数据源
+    if not profile.domestic_ok:
+        diagnostics.append({
+            "group": "domestic",
+            "status": "🔴 不通",
+            "affected_fetchers": ["fetch_basic", "fetch_financials", "fetch_industry", "fetch_peers",
+                                  "fetch_events", "fetch_capital_flow", "fetch_lhb", "fetch_fund_holders"],
+            "affected_count": 8,
+            "fix": (
+                "主要问题：push2.eastmoney.com / cninfo / xueqiu 全挂 · 绝大多数 fetcher 无法工作\n"
+                "  1. 检查 VPN 是否指向国内 IP（海外 VPN 会被东财反向 GFW）\n"
+                "  2. 尝试：unset HTTPS_PROXY HTTP_PROXY ALL_PROXY\n"
+                "  3. 如用 Clash · 检查规则是否把 *.eastmoney.com / cninfo / xueqiu.com 走 direct"
+            ),
+        })
+    elif profile.domestic_count < 3:
+        diagnostics.append({
+            "group": "domestic",
+            "status": "⚠ 部分不通",
+            "affected_fetchers": ["受影响具体域名见 checks 明细"],
+            "affected_count": 3 - profile.domestic_count,
+            "fix": "多数 fetcher 仍可工作 · 查 checks 明细看具体是哪个域名不通",
+        })
+
+    # Overseas 数据源
+    if not profile.overseas_ok:
+        diagnostics.append({
+            "group": "overseas",
+            "status": "🔴 不通",
+            "affected_fetchers": ["yfinance(_kline_us_chain)", "_yahoo_v8_chart", "CoinGecko / Binance / ECB"],
+            "affected_count": 3,
+            "fix": (
+                "Yahoo / CoinGecko 等海外源挂 · 美股 / 港股 / 加密数据会降级\n"
+                "  1. 确认 VPN 能访问海外（浏览器访问 finance.yahoo.com 测试）\n"
+                "  2. 中国大陆不需要海外源就能分析 A 股 · 此项可忽略\n"
+                "  3. 若必须：开 Clash 全局模式 + export HTTPS_PROXY=http://127.0.0.1:7890"
+            ),
+        })
+
+    # Search 数据源
+    if not profile.search_ok:
+        diagnostics.append({
+            "group": "search",
+            "status": "🔴 不通",
+            "affected_fetchers": ["fetch_moat", "fetch_industry(dynamic)", "fetch_policy",
+                                  "fetch_sentiment(ddgs)", "fetch_trap_signals"],
+            "affected_count": 5,
+            "fix": (
+                "DuckDuckGo / 百度搜索 全挂 · 5 个定性维度将降级\n"
+                "  1. 百度搜索被挡：中国大陆一般能通 · 检查是否 DNS 污染\n"
+                "  2. DDGS 被挡：走 VPN 或切百度搜索作为唯一源\n"
+                "  3. 实在不通：设 UZI_SKIP_WS=1 跳过 web search 部分（报告 5 个定性维度标 gap）"
+            ),
+        })
+
+    return diagnostics
 
 
 def _build_recommendation(p: NetworkProfile) -> tuple[str, str]:
@@ -193,6 +311,9 @@ def run_preflight(verbose: bool = True, timeout: float = 3.0) -> NetworkProfile:
     if reachable_latencies:
         avg_lat = int(sum(reachable_latencies) / len(reachable_latencies))
 
+    # v2.15.2 (#30) · 本地代理端口自检
+    local_proxy_info = _detect_local_proxy()
+
     prof = NetworkProfile(
         domestic_ok=dom_ok >= 2,        # 3 个有 2 个通算 ok
         overseas_ok=ovs_ok >= 2,
@@ -205,8 +326,11 @@ def run_preflight(verbose: bool = True, timeout: float = 3.0) -> NetworkProfile:
         avg_latency_ms=avg_lat,
         probed_at=time.time(),
         checks=[asdict(r) for r in results],
+        local_proxy=local_proxy_info,
     )
     prof.recommendation, prof.severity = _build_recommendation(prof)
+    # v2.15.2 (#30) · 分组诊断 + 修复建议
+    prof.diagnostics = diagnose_source(prof)
 
     if verbose:
         total = len(results)
@@ -221,7 +345,18 @@ def run_preflight(verbose: bool = True, timeout: float = 3.0) -> NetworkProfile:
             for r in grp:
                 mark = f"✓ {r.latency_ms:4d}ms" if r.reachable else f"✗ {r.error[:35]}"
                 print(f"    {mark}  {r.domain:32} · {r.purpose}")
-        print(f"\n  {prof.recommendation}\n")
+        print(f"\n  {prof.recommendation}")
+
+        # v2.15.2 (#30) · Clash 检测 + 具体诊断
+        if local_proxy_info.get("hint"):
+            print(f"  {local_proxy_info['hint']}")
+        if prof.diagnostics:
+            print(f"\n  🔧 数据源诊断（{len(prof.diagnostics)} 组受影响）")
+            for diag in prof.diagnostics:
+                print(f"     [{diag['group']}] {diag['status']} · 影响 {diag.get('affected_count', '?')} 个 fetcher")
+                for line in diag.get("fix", "").split("\n"):
+                    print(f"       {line}")
+        print()
 
     # 写 cache 供 agent 介入时读
     try:

--- a/skills/deep-analysis/scripts/tests/test_v2_15_2_network_enhance.py
+++ b/skills/deep-analysis/scripts/tests/test_v2_15_2_network_enhance.py
@@ -1,0 +1,164 @@
+"""Regression tests for v2.15.2 · issue #30 网络自检增强 (Clash + 分组诊断) + #36 gemini manifest."""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+SCRIPTS = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(SCRIPTS))
+ROOT = SCRIPTS.parent.parent.parent
+
+
+# ─── #36 · Gemini CLI ──────────────────────────────────────────
+
+def test_gemini_extension_has_version():
+    """Gemini CLI 需要 version 字段 · 没这个字段 install 会挂."""
+    path = ROOT / "gemini-extension.json"
+    assert path.exists()
+    data = json.loads(path.read_text(encoding="utf-8"))
+    assert "version" in data, "gemini-extension.json 必须有 version 字段（否则 Gemini CLI 安装失败）"
+    # 应该跟主 manifest 一致
+    main_manifest = json.loads((ROOT / ".claude-plugin" / "plugin.json").read_text(encoding="utf-8"))
+    # 至少同大版本
+    assert data["version"].split(".")[0] == main_manifest["version"].split(".")[0]
+
+
+def test_version_bump_config_includes_gemini():
+    """version-bump.json 必须含 gemini-extension.json · 否则下次 bump 会遗漏."""
+    config = json.loads((ROOT / ".version-bump.json").read_text(encoding="utf-8"))
+    assert "gemini-extension.json" in config.get("files", [])
+    assert "gemini-extension.json" in config.get("patterns", {})
+
+
+# ─── #30 · 本地代理端口检测 ───────────────────────────────────
+
+def test_detect_local_proxy_returns_expected_shape():
+    from lib.network_preflight import _detect_local_proxy
+    info = _detect_local_proxy()
+    assert "has_local_proxy" in info
+    assert "detected" in info
+    assert "hint" in info
+    assert isinstance(info["detected"], list)
+
+
+def test_detect_local_proxy_with_mocked_clash_port():
+    """mock Clash 7890 打开 + env 未设 · 应给出 export 建议."""
+    from lib import network_preflight as np
+    import socket
+
+    def fake_create_connection(addr, timeout=0.3):
+        host, port = addr
+        if host == "127.0.0.1" and port == 7890:
+            # fake 一个 socket
+            class _FakeSocket:
+                def close(self): pass
+            return _FakeSocket()
+        raise ConnectionRefusedError()
+
+    with patch.object(socket, "create_connection", side_effect=fake_create_connection):
+        # 清 env
+        import os
+        saved = {}
+        for k in ("HTTPS_PROXY", "HTTP_PROXY", "ALL_PROXY",
+                  "https_proxy", "http_proxy", "all_proxy"):
+            saved[k] = os.environ.pop(k, None)
+        try:
+            info = np._detect_local_proxy()
+            assert info["has_local_proxy"] is True
+            assert any(d["port"] == 7890 for d in info["detected"])
+            assert "export HTTPS_PROXY" in info["hint"]
+            assert "7890" in info["hint"]
+        finally:
+            for k, v in saved.items():
+                if v is not None:
+                    os.environ[k] = v
+
+
+# ─── #30 · 分组诊断 ──────────────────────────────────────────
+
+def test_diagnose_source_all_broken_gives_3_groups():
+    from lib.network_preflight import diagnose_source, NetworkProfile
+    p = NetworkProfile(
+        domestic_ok=False, overseas_ok=False, search_ok=False,
+        domestic_count=0, overseas_count=0, search_count=0,
+    )
+    diags = diagnose_source(p)
+    assert len(diags) == 3
+    groups = {d["group"] for d in diags}
+    assert groups == {"domestic", "overseas", "search"}
+    # 每组必须有 affected_fetchers + fix
+    for d in diags:
+        assert d.get("affected_fetchers")
+        assert d.get("fix")
+        assert d.get("status")
+
+
+def test_diagnose_source_all_ok_no_diagnostics():
+    from lib.network_preflight import diagnose_source, NetworkProfile
+    p = NetworkProfile(
+        domestic_ok=True, overseas_ok=True, search_ok=True,
+        domestic_count=3, overseas_count=3, search_count=3,
+    )
+    diags = diagnose_source(p)
+    assert diags == [], "全通时不应有诊断"
+
+
+def test_diagnose_partial_domestic_only_one_warning():
+    from lib.network_preflight import diagnose_source, NetworkProfile
+    p = NetworkProfile(
+        domestic_ok=True, overseas_ok=False, search_ok=True,
+        domestic_count=2, overseas_count=0, search_count=3,  # 1 个国内挂但不影响 ok
+    )
+    diags = diagnose_source(p)
+    # 国内 2/3 但还算 ok · 只应看到 overseas 问题
+    groups = {d["group"] for d in diags}
+    assert "overseas" in groups
+    assert "search" not in groups  # 搜索通
+
+
+def test_network_profile_has_new_fields():
+    """v2.15.2 · NetworkProfile 新增 local_proxy + diagnostics."""
+    from lib.network_preflight import NetworkProfile
+    p = NetworkProfile()
+    assert hasattr(p, "local_proxy")
+    assert hasattr(p, "diagnostics")
+
+
+def test_run_preflight_populates_diagnostics(monkeypatch):
+    """run_preflight 完成时 · diagnostics 应被填入."""
+    from lib import network_preflight as np
+
+    def fake_probe(domain, port=443, timeout=3.0):
+        # 模拟全不通 · 会触发 3 组诊断
+        return np.DomainCheck(domain=domain, group="", reachable=False,
+                              latency_ms=0, error="blocked")
+
+    with patch.object(np, "_probe", side_effect=fake_probe), \
+         patch.object(np, "_detect_local_proxy",
+                      return_value={"has_local_proxy": False, "detected": [], "hint": ""}):
+        prof = np.run_preflight(verbose=False)
+
+    assert prof.domestic_ok is False
+    assert prof.overseas_ok is False
+    assert prof.search_ok is False
+    assert len(prof.diagnostics) == 3  # 全挂 · 3 组都有诊断
+    assert prof.local_proxy == {"has_local_proxy": False, "detected": [], "hint": ""}
+
+
+def test_run_preflight_writes_enhanced_cache(monkeypatch):
+    """run_preflight 写的 cache 必须含 local_proxy + diagnostics."""
+    from lib import network_preflight as np
+
+    def fake_probe(domain, port=443, timeout=3.0):
+        return np.DomainCheck(domain=domain, group="", reachable=True, latency_ms=5)
+
+    with patch.object(np, "_probe", side_effect=fake_probe):
+        prof = np.run_preflight(verbose=False)
+
+    cache = SCRIPTS / ".cache" / "_global" / "network_profile.json"
+    assert cache.exists()
+    data = json.loads(cache.read_text(encoding="utf-8"))
+    assert "local_proxy" in data
+    assert "diagnostics" in data


### PR DESCRIPTION
## Summary

社区反馈 2 个 issue · 都是可直接修复的：

- **#36** · Veitkwok 报告 Gemini CLI 安装报错（gemini-extension.json 缺 version 字段）
- **#30** · 3150214587 希望代理 / 数据源自检修复机制

## Bug 1 · Gemini CLI 安装报错（#36）

`gemini-extension.json` 加 `"version": "2.15.2"` · `.version-bump.json::files` 纳入该 manifest · 未来 bump 自动同步。

## Feature 2 · 网络自检增强（#30）

`lib/network_preflight.py`
- `_detect_local_proxy()` · 扫 6 常见代理端口
- `diagnose_source(profile)` · 3 组独立诊断 · 每组列受影响 fetcher + 多行 fix
- `NetworkProfile` 新增 `local_proxy` + `diagnostics` 字段
- verbose 输出 · Clash hint + 每组 fix

## Test plan

- [x] pytest 全量 265 passed（255 baseline + 10 新 · 零回归）
- [x] Playwright 环境实测：Clash Verge 7897 被准确侦测并给出 `export HTTPS_PROXY=http://127.0.0.1:7897` 建议
- [x] 5 manifest 同步 2.15.1 → 2.15.2（新增 gemini-extension.json）

Closes #36
Closes #30

🤖 Generated with [Claude Code](https://claude.com/claude-code)