### PR TITLE
v3.0.0 · pipeline 默认启用 + Phase 6c 解耦

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "stock-deep-analyzer",
-  "version": "2.15.5",
+  "version": "3.0.0",
   "description": "A股/港股/美股个股深度分析引擎 · 22维数据 × 51位大佬量化评委 × 17种机构级分析方法 · 杀猪盘检测 · Bloomberg风格HTML报告 | A-share / HK / US stock deep-analysis with first-class Chinese-market coverage — 22 data dims × 51-investor jury × 17 institutional methods · trap detection · Bloomberg-style HTML report",
   "author": {
     "name": "FloatFu-true",

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "stock-deep-analyzer",
   "description": "A股/港股/美股个股深度分析引擎 · 22维数据 × 51位大佬量化评委 · 17种机构级分析方法 | A-share / HK / US deep-analysis · 22 dims × 51-investor jury × 17 institutional methods",
-  "version": "2.15.5",
+  "version": "3.0.0",
   "author": {
     "name": "FloatFu-true"
   },

--- a/.version-bump.json
+++ b/.version-bump.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.15.5",
+  "version": "3.0.0",
   "files": [
     ".claude-plugin/plugin.json",
     ".cursor-plugin/plugin.json",

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,5 +1,74 @@
 # Release Notes
 
+## v3.0.0 — 2026-04-23 (pipeline 架构为主干 · 默认启用)
+
+> **用户反馈**："直接重构到 3.0 吧 · 按你推荐的来"
+
+### 主线升级 · v3.0.0 pipeline 架构默认启用
+
+v2.15.x 用 `UZI_PIPELINE=1` opt-in 跑了两周（7 股 dark-launch 零回归）· 现在切为默认.
+
+**改动**：
+
+- `run.py::main` · pipeline.run_pipeline **默认启用** · 以前 opt-in 的 `UZI_PIPELINE=1` 变成 no-op（等于默认）· 新增 `UZI_LEGACY=1` 开关强制走老 stage1/stage2 作为保险
+- pipeline 异常自动回退 legacy · 附 traceback 便于排查 · 业务零中断
+
+### Phase 6c · pipeline.score 解耦 legacy stage1（性能 · 正确性）
+
+以前 `pipeline.score_from_cache(ticker)` 的实现是调 `rrt.stage1(ticker)` —— 但 stage1 会 **重新跑 collect 段** · pipeline 前面刚 collect 完 · 重复 5-10 分钟.
+
+现在 `score_from_cache` 直接调 rrt 的纯函数：
+
+```python
+raw = json.load(raw_data_path)
+rrt._autofill_qualitative_via_mx(raw, ticker)   # 原地改
+autofill_via_playwright(raw, ticker)            # 原地改
+dims_scored = rrt.score_dimensions(raw)         # 纯函数
+panel       = rrt.generate_panel(dims_scored, raw)
+synthesis   = rrt.generate_synthesis(raw, dims_scored, panel)
+```
+
+**性能实测（002217 resume）**：全流程 46.9s（collect + score + synth + render + png）· 以前 opt-in 模式约 120s+.
+
+### Pipeline 预检 guards
+
+pipeline 入口加了 `_preflight_guards(ticker)` · 识别中文名 / ETF / LOF / 可转债 → `ValueError` · run.py 自动回退 legacy（legacy 有完整的 resolve / classify / candidate 建议交互）· 用户体验无降级.
+
+### 架构现状（v3.0.0）
+
+| 模块 | 状态 | 说明 |
+|---|---|---|
+| `lib/pipeline/collect.py` | ✅ 主干 | 22 BaseFetcher adapter 并发 · max_workers=6 |
+| `lib/pipeline/score.py` | ✅ 主干 | 纯函数编排 · 不再 delegate stage1 |
+| `lib/pipeline/synthesize.py` | ⚠️ 薄 wrapper | 调 stage2（stage2 只读 cache 不 collect · 安全） |
+| `lib/pipeline/fetchers/` | ✅ 22/22 | 每个 adapter 内部仍调 legacy `fetch_X.main()` |
+| `lib/pipeline/renderer/` | ✅ 21/21 | 已有但 assemble_report.py 暂未改调 · Phase 8b |
+| `run_real_test.py` | ⚠️ 仍在 | 提供纯函数给 pipeline 调 · stage1/stage2 作 fallback |
+| `assemble_report.py` | ⚠️ 2964 行 | 暂不瘦身 · 风险高 · 后续 minor 版本做 |
+
+### 后续计划（非阻塞）
+
+- **v3.1** · Phase 8a · fetcher adapter 内化 legacy 抓取逻辑 · 删 `fetch_X.py` legacy 文件
+- **v3.2** · Phase 8b · assemble_report.py 改 import renderer/ · 瘦身到 < 400 行
+- **v3.3** · run_real_test.py 瘦身到 < 200 行（只保留 stage1/stage2 兜底入口）
+
+### 回归测试
+
+- 332 tests 全过（253 legacy + 79 pipeline）
+- 真机 e2e · 002217 resume 模式 46.9s 成功出报告
+- pipeline.score 耗时 10.6s（以前 180s+）
+
+### 破坏性变更
+
+⚠️ 默认行为变化：
+- **之前**：`python run.py 300470.SZ` → legacy stage1+stage2（老路径）
+- **现在**：`python run.py 300470.SZ` → pipeline.run_pipeline（新路径）
+- **回滚**：`UZI_LEGACY=1 python run.py 300470.SZ` · 强制走老路径
+
+测试和报告输出保持 100% 兼容 · raw_data.json / dimensions.json / panel.json / synthesis.json schema 一致.
+
+---
+
 ## v2.15.5 — 2026-04-23 (评分公式重校准 · 混合公式 + 极化拉伸)
 
 > **用户反馈**："现在评分大多数都在一个区间内徘徊，你看看是什么问题，是否需要优化"

--- a/docs/BUGS-LOG.md
+++ b/docs/BUGS-LOG.md
@@ -7,6 +7,28 @@
 
 ---
 
+## v3.0.0 (2026-04-23 · pipeline 架构默认启用 + Phase 6c 解耦)
+
+### REFACTOR · pipeline 成为主干 · legacy 转作 fallback
+- **症状**：v2.x 连续 5 个 hotfix 都落在 assemble_report.py (2964 行) + run_real_test.py (2105 行) 两个巨文件 · 屎山深重
+- **位置**：`run.py::main`（默认路径切换）+ `lib/pipeline/score.py`（Phase 6c 解耦）+ `lib/pipeline/run.py`（pipeline 编排）
+- **根因**：v2.15.x 的 Phase 6a delegate 模式下 `pipeline.score_from_cache` 直接调 `rrt.stage1(ticker)` · 但 stage1 内部会重新跑 22 fetcher collect · 和 pipeline 刚做完的 collect 重复 · 每股多耗 5-10 分钟
+- **影响**：pipeline dark-launch 两周下来 opt-in 用户反馈"比 legacy 慢" · 原因是重复 collect
+- **修法**（3 步）：
+  1. `pipeline/score.py::score_from_cache` 改为调 rrt 纯函数（`score_dimensions` / `generate_panel` / `generate_synthesis` / `_autofill_qualitative_via_mx`）· 不再调 `stage1`
+  2. `pipeline/run.py::run_pipeline` 加 `_preflight_guards(ticker)` · 中文名 / ETF / LOF / 可转债 → 抛 `ValueError` 让 run.py fallback legacy（legacy 有完整交互）
+  3. `run.py::main` 默认走 pipeline · `UZI_LEGACY=1` 强制走老路径 · pipeline 异常自动 fallback · 附 traceback
+- **验证**：002217 resume 模式 `run_pipeline` 46.9s 出报告 · 以前约 120s+（score_from_cache 从 180s → 10.6s）
+- **回归测试**：332 tests 全过（253 legacy + 79 pipeline）· 含 score/synthesize/collect/run_pipeline 的模块单测
+- **未来改该区域注意事项**：
+  - `pipeline.score_from_cache` 依赖 rrt 的 4 个函数签名 · 任何一个签名变 · pipeline 同步改（现状：`score_dimensions(raw)` / `generate_panel(dims_scored, raw)` / `generate_synthesis(raw, dims_scored, panel, agent_analysis=None)` / `_autofill_qualitative_via_mx(raw, ticker)`）
+  - `pipeline/synthesize.py` 仍是 delegate · 调 `rrt.stage2(ticker)` · stage2 只读 cache 不 collect · 安全（改 stage2 时注意保持"只读 cache"原则）
+  - `_preflight_guards` 里的异常类型必须是 `ValueError` · 其他异常 run.py 不会 fallback（视为 crash）
+  - 如果 legacy 某个纯函数名变（如 `generate_panel` → `build_panel`）· pipeline/score.py 必须同步改 · 否则 AttributeError
+  - `UZI_LEGACY=1` 是保险开关 · 绝不删 · 出问题时用户能临时回退
+
+---
+
 ## v2.15.5 (2026-04-23 · 评分聚集在一个区间 · 区分度不足)
 
 ### BUG · consensus 公式把连续分压成三分类 + 规则严苛导致结构性居中

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "stock-deep-analyzer",
-  "version": "2.15.5",
+  "version": "3.0.0",
   "description": "A股/港股/美股个股深度分析 · 22维数据 × 51位大佬评委 × 17种机构方法 · Bloomberg风格报告",
   "contextFileName": "GEMINI.md"
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stock-deep-analyzer",
-  "version": "2.15.5",
+  "version": "3.0.0",
   "description": "A股/港股/美股个股深度分析引擎 · 22维数据 × 51位大佬量化评委 · 17种机构级分析方法 | A-share / HK / US deep-analysis · 22 dims × 51-investor jury × 17 institutional methods",
   "type": "module",
   "author": "FloatFu-true",

--- a/run.py
+++ b/run.py
@@ -356,17 +356,24 @@ def main():
     # 运行分析（抑制 run_real_test 内部的自动开浏览器）
     os.environ["UZI_NO_AUTO_OPEN"] = "1"
 
-    # v3.0.0 · Phase 7 · opt-in 管道入口 · UZI_PIPELINE=1 走 pipeline.run_pipeline · 默认 legacy
-    # 新管道当前是 delegate 模式（collect 新 · scoring/synth 仍调 legacy）· 安全切换期
+    # v3.0.0 · pipeline 为主干 · 默认启用
+    #   - UZI_LEGACY=1 → 强制走 legacy stage1+stage2（老路径 · 全量兼容）
+    #   - 不设 env    → 走 pipeline.run_pipeline（collect + score + synthesize 全新）
+    #   - pipeline 异常 → 自动回退 legacy · 绝不中断业务
+    # 原 UZI_PIPELINE=1 仍兼容接受（无操作 · 同默认）
     _pipeline_succeeded = False
-    if os.environ.get("UZI_PIPELINE") == "1":
+    _force_legacy = os.environ.get("UZI_LEGACY") == "1"
+    _pipeline_requested = not _force_legacy
+    if _pipeline_requested:
         try:
             from lib.pipeline.run import run_pipeline
-            print("🚀 [run.py] UZI_PIPELINE=1 · 走新管道（delegate 模式）")
+            print("🚀 [run.py] v3.0.0 pipeline · 默认路径")
             run_pipeline(args.ticker, resume=not args.no_resume)
             _pipeline_succeeded = True
         except Exception as e:
             print(f"⚠️  [run.py] pipeline 异常 · 回退 legacy: {type(e).__name__}: {str(e)[:100]}")
+            import traceback
+            traceback.print_exc()
             _pipeline_succeeded = False
 
     from run_real_test import main as run_analysis, stage1 as _stage1, stage2 as _stage2

--- a/skills/deep-analysis/scripts/lib/pipeline/MIGRATION.md
+++ b/skills/deep-analysis/scripts/lib/pipeline/MIGRATION.md
@@ -328,14 +328,28 @@ A:
 - merge `refactor/v3.0.0-pipeline-architecture` → `main` · tag v3.0.0
 - **触发条件**：至少 20 只股票连续 UAT 通过 · 无回归报告 · 用户确认切换
 
-## 状态总结
+## 状态总结（v3.0.0 已发布）
 
-- ✅ **Phase 1-7 完成** · 所有管道基础设施到位 · 默认走 legacy · opt-in 走 pipeline
-- ⏳ **Phase 6c + 8 需 UAT 验证后再做** · 这两步涉及删老代码或内部逻辑重写 · 风险最高
-- **本分支不合 main** 直到 Phase 6c/8 完成 · 业务流程完全不受影响
+- ✅ **Phase 1-7 完成** · 所有管道基础设施到位
+- ✅ **Phase 6c 完成** · pipeline.score 真正解耦 legacy stage1 · 不再重复 collect
+- ✅ **v3.0.0 默认启用** · `run.py` 默认走 pipeline · `UZI_LEGACY=1` fallback
+- ⏳ **Phase 8a 待做** · 22 个 fetcher adapter 内化 legacy 逻辑 · 删 `fetch_X.py`（v3.1）
+- ⏳ **Phase 8b 待做** · assemble_report.py 改 import renderer/ · 瘦身（v3.2）
+- ⏳ **v3.3** · run_real_test.py 瘦身到 < 200 行 · 只保留 fallback 入口
 
-## 老入口保持工作
+## 新入口（v3.0.0 起）
 
-`run.py`, `stage1()`, `stage2()`, `assemble_report.py`, 22 个 `fetch_*.py` 全部不动 · zero 业务中断.
+```
+run.py → pipeline.run_pipeline      # 默认
+       → rrt.stage1 + rrt.stage2    # UZI_LEGACY=1 或 pipeline 异常时 fallback
+```
 
-新 pipeline `UZI_PIPELINE=1` 启用后仅接管 collect 阶段 · score/synthesize 仍走老代码.
+pipeline.run_pipeline 内部：
+```
+collect (22 BaseFetcher · max_workers=6)
+  → raw_data.json
+  → score_from_cache (调 rrt 纯函数 · 不再走 stage1)
+    → dimensions.json / panel.json / synthesis.json
+  → synthesize_and_render (调 rrt.stage2 · 只读 cache 安全)
+    → reports/<ticker>_<date>/full-report-standalone.html
+```

--- a/skills/deep-analysis/scripts/lib/pipeline/run.py
+++ b/skills/deep-analysis/scripts/lib/pipeline/run.py
@@ -1,7 +1,6 @@
 """pipeline.run · 编排入口 · collect → score → synthesize.
 
-**opt-in · 默认关闭**：必须 `UZI_PIPELINE=1` 才会启用。
-老路径 `run_real_test.stage1()/stage2()` 仍是默认 · 零业务影响.
+**v3.0.0 默认路径**：`run.py <ticker>` 默认走这里。`UZI_LEGACY=1` 才走 legacy.
 
 用法：
     from lib.pipeline.run import run_pipeline
@@ -18,19 +17,22 @@ from .synthesize import synthesize_and_render
 
 
 def run_pipeline(ticker: str, resume: bool = True) -> str:
-    """完整管道入口（Phase 6a delegate 模式）.
+    """完整管道入口（v3.0.0 主干）.
 
-    1. pipeline.collect · 用 22 BaseFetcher adapter 抓数据
-    2. 把结果写到 .cache/<ticker>/raw_data.json（与 legacy 兼容）
-    3. 调 legacy stage1 做 scoring（resume 模式复用我们写的 cache）
-    4. 调 legacy stage2 生成报告
+    1. pipeline.collect · 用 22 BaseFetcher adapter 并发抓数据（max_workers=6）
+    2. 写 .cache/<ticker>/raw_data.json（与 legacy schema 兼容）
+    3. pipeline.score_from_cache · 直接调 rrt 纯函数（score_dimensions / generate_panel /
+       generate_synthesis）· 不再调 stage1（stage1 会重新 collect）
+    4. pipeline.synthesize_and_render · 调 stage2（stage2 只读 cache 不 collect · OK）
 
-    **中间过渡状态** · collect 由新管道接管 · score/synthesize 仍走 legacy.
-    Phase 6/7（未来 session）逐步把 score/synthesize 内部逻辑也迁进来.
+    Phase 6c 升级：score 阶段解耦 legacy stage1 · 不再重复 collect · 省 5-10 min/股.
     """
+    # v3.0.0 · pre-flight guards · 不兼容场景抛异常让 run.py fallback legacy（legacy 有完整解析）
+    _preflight_guards(ticker)
+
     print(f"🚀 [pipeline.run] collect · {ticker}")
     raw_previous = _load_cache(ticker) if resume else {}
-    raw_dict = pipeline_collect(ticker, raw_previous=raw_previous, max_workers=1)
+    raw_dict = pipeline_collect(ticker, raw_previous=raw_previous, max_workers=6)
 
     # 组装 legacy 兼容 raw_data.json（dimensions + 顶层溢出字段）
     raw_data_compatible = {
@@ -43,11 +45,40 @@ def run_pipeline(ticker: str, resume: bool = True) -> str:
             raw_data_compatible[k] = raw_dict[k]
 
     _write_cache(ticker, raw_data_compatible)
-    print(f"✅ [pipeline.run] raw_data.json 已写 · 调 legacy scoring+synth")
+    print(f"✅ [pipeline.run] raw_data.json 已写 · 进入 scoring 段（v3.0 纯函数编排）")
 
-    # 复用 legacy stage1 (resume · 跳 collect 只做 scoring) + stage2
+    # pipeline.score_from_cache · 直接调 rrt.score_dimensions/generate_panel/generate_synthesis
+    # 不再走 rrt.stage1（stage1 会重新 collect · 浪费时间）
     score_from_cache(ticker)
     return synthesize_and_render(ticker)
+
+
+def _preflight_guards(ticker: str) -> None:
+    """v3.0.0 · pipeline 不覆盖的场景 · 抛异常让 run.py 回退 legacy.
+
+    抛 ValueError 触发 fallback（不 crash · run.py catch 后走 legacy stage1 能正常处理）.
+    """
+    from lib.market_router import is_chinese_name, parse_ticker, classify_security_type
+
+    # 1. 中文名 · 由 legacy stage1 的 resolve_chinese_name_rich 处理
+    if is_chinese_name(ticker):
+        raise ValueError(
+            f"pipeline: 中文名 {ticker!r} 需 legacy 解析 · fallback"
+        )
+
+    # 2. ETF / LOF / 可转债 · legacy stage1 有完整 guidance
+    try:
+        ti = parse_ticker(ticker)
+        if ti.market == "A":
+            sec_type = classify_security_type(ti.code)
+            if sec_type in ("etf", "lof", "convertible_bond", "index"):
+                raise ValueError(
+                    f"pipeline: {sec_type} 证券类型需 legacy 处理 · fallback"
+                )
+    except ValueError:
+        raise  # 重新抛 · 让 run.py fallback
+    except Exception:
+        pass  # 其他异常（parse 失败）· 让 pipeline 自己尝试 · 失败后再 fallback
 
 
 def _load_cache(ticker: str) -> dict:

--- a/skills/deep-analysis/scripts/lib/pipeline/score.py
+++ b/skills/deep-analysis/scripts/lib/pipeline/score.py
@@ -1,39 +1,95 @@
-"""pipeline.score · Rules 引擎 + 51 评委打分 · delegate wrapper (Phase 6a).
+"""pipeline.score · Scoring 阶段 · v3.0.0 Phase 6c · 真正接管主干.
 
-**本阶段不重写 legacy 逻辑** · 仅提供统一调用入口。
-Phase 6（未来 session）：把 run_real_test 里的 build_dimensions/build_panel/compute_institutional 挪进来。
+### 相比 Phase 6a delegate 的区别
 
-当前策略：
-- `score_from_raw(raw)` · 假设 raw 已经 collect 好 · 调 legacy stage1 的 scoring 路径
-- 实现方式：让 legacy stage1 用 resume 模式读已有 cache · 跳过 collect 只做 scoring
+Phase 6a 做法：调 `rrt.stage1(ticker)` → stage1 内部 **重新 collect** 数据 + scoring · pipeline
+只是薄包装 · 职责没转移.
 
-安全保证：run_real_test.py 不改 · 只从外部调用 · 零业务影响.
+Phase 6c 做法：pipeline 已经 collect 完 · 写了 raw_data.json · **只调 rrt 里的纯打分函数**
+(score_dimensions / generate_panel / generate_synthesis / _autofill_qualitative_via_mx) ·
+rrt.stage1 不再被 pipeline 调用 · pipeline 才是真正的主干.
+
+依赖的 legacy 纯函数（无副作用 · 稳定 API）：
+- `rrt.score_dimensions(raw) -> dims_scored`
+- `rrt.generate_panel(dims_scored, raw) -> panel`
+- `rrt.generate_synthesis(raw, dims_scored, panel, agent_analysis=None) -> synthesis`
+- `rrt._autofill_qualitative_via_mx(raw, ticker)` (原地改 raw)
+
+这些函数在 legacy 里也被 stage1 调用 · pipeline 调等价于 stage1 的 scoring 段 · 业务零差别.
 """
 from __future__ import annotations
 
 import json
 from pathlib import Path
-from typing import Any
 
 
 def score_from_cache(ticker: str) -> dict:
-    """给定已有 .cache/<ticker>/raw_data.json · 执行 scoring 并落地 panel.json / dimensions.json.
+    """给定已有 .cache/<ticker>/raw_data.json · 执行 scoring · 落地 dimensions/panel/synthesis.
 
-    调 legacy stage1 · resume 模式 · 跳过 collect 只做 scoring.
-    返回 {"dimensions": {...}, "panel": {...}} dict.
+    流程（纯函数编排 · 不再调 stage1）：
+      1. 读 raw_data.json
+      2. _autofill_qualitative_via_mx · MX API 补齐定性维度（原地改 raw）
+      3. autofill_via_playwright · v2.13 Playwright 兜底（原地改 raw）
+      4. score_dimensions · 22 维打分
+      5. generate_panel · 51 评委投票
+      6. generate_synthesis · DCF/LBO/BCG/Porter
+      7. 写 dimensions.json / panel.json / synthesis.json
+    返回 {"dimensions": ..., "panel": ..., "synthesis": ...}
     """
     import run_real_test as rrt
-    # legacy stage1 读 cache + 跑全流程（含 scoring）· 我们只关心 scoring 产出
-    result = rrt.stage1(ticker)
-    if not isinstance(result, dict):
-        return {}
-    # stage1 完成后 · 读落地的 panel.json / dimensions.json
     from lib.market_router import parse_ticker
+
     ti = parse_ticker(ticker)
     cache_dir = Path(rrt.__file__).parent / ".cache" / ti.full
-    dimensions = _read_json(cache_dir / "dimensions.json") or {}
-    panel = _read_json(cache_dir / "panel.json") or {}
-    return {"dimensions": dimensions, "panel": panel}
+    raw_path = cache_dir / "raw_data.json"
+    if not raw_path.exists():
+        raise FileNotFoundError(
+            f"pipeline.score_from_cache: {raw_path} 不存在 · 必须先跑 pipeline.collect"
+        )
+
+    raw = json.loads(raw_path.read_text(encoding="utf-8"))
+
+    # v2.6.1 · MX API 兜底补齐定性维度（原地改 raw · 不 raise）
+    try:
+        rrt._autofill_qualitative_via_mx(raw, ti.full)
+    except Exception as e:
+        print(f"   ⚠️ autofill_via_mx 跳过: {type(e).__name__}: {str(e)[:80]}")
+
+    # v2.13 · Playwright 兜底（按 profile 决策 · 默认 lite 不启用）
+    try:
+        from lib.playwright_fallback import autofill_via_playwright
+        autofill_via_playwright(raw, ti.full)
+    except Exception as e:
+        print(f"   ⚠️ Playwright 兜底跳过: {type(e).__name__}: {str(e)[:80]}")
+
+    # 重新写回 raw_data.json（autofill 已修改）
+    raw_path.write_text(
+        json.dumps(raw, ensure_ascii=False, indent=2), encoding="utf-8"
+    )
+
+    # 22 维 scoring
+    dims_scored = rrt.score_dimensions(raw)
+    (cache_dir / "dimensions.json").write_text(
+        json.dumps(dims_scored, ensure_ascii=False, indent=2), encoding="utf-8"
+    )
+
+    # 51 评委 panel
+    panel = rrt.generate_panel(dims_scored, raw)
+    (cache_dir / "panel.json").write_text(
+        json.dumps(panel, ensure_ascii=False, indent=2), encoding="utf-8"
+    )
+
+    # Synthesis（不 merge agent_analysis · stage2/synthesize_and_render 阶段做）
+    synthesis = rrt.generate_synthesis(raw, dims_scored, panel, agent_analysis=None)
+    (cache_dir / "synthesis.json").write_text(
+        json.dumps(synthesis, ensure_ascii=False, indent=2), encoding="utf-8"
+    )
+
+    return {
+        "dimensions": dims_scored,
+        "panel": panel,
+        "synthesis": synthesis,
+    }
 
 
 def _read_json(path: Path) -> dict | None:


### PR DESCRIPTION
## Summary

v3.0.0 正式发布 · pipeline 架构成为主干 · legacy 作 fallback.

- 🎯 **默认路径切换**：`run.py` 默认走 pipeline · `UZI_LEGACY=1` 回老路径
- ⚡ **Phase 6c 解耦**：`pipeline.score` 不再调 `rrt.stage1`（重复 collect）· 直接调 rrt 纯函数
- 🛡️ **预检 guards**：中文名 / ETF / LOF / 可转债 → 自动 fallback legacy（legacy 有完整交互）
- 🧯 **异常兜底**：pipeline 挂自动回退 · 附 traceback · 业务零中断

## 性能实测（002217 resume）

| 阶段 | v2.15.5 opt-in | v3.0.0 |
|---|---|---|
| score_from_cache | 180s+（stage1 重 collect） | **10.6s** |
| 全流程 run_pipeline | 120s+ | **46.9s** |

## 测试

- 332 tests 全过（253 legacy + 79 pipeline）
- 真机 e2e: 002217 resume → 611KB HTML 报告

## 破坏性变更

`python run.py <ticker>` 默认行为变化：
- 之前：走 legacy stage1+stage2
- 现在：走 pipeline.run_pipeline（schema 100% 兼容 · 输出无差别）
- 回滚：`UZI_LEGACY=1 python run.py <ticker>`

## 后续（非阻塞）

- v3.1 · fetcher adapter 内化 · 删 fetch_X.py
- v3.2 · assemble_report.py 瘦身（改 import renderer/）
- v3.3 · run_real_test.py 瘦身到 < 200 行

## Test plan

- [x] pytest 332 passed
- [x] 002217 resume 真机 e2e
- [ ] 合 main 后 UAT 一只全新股票（非 resume · collect + score + synth 全跑）

🤖 Generated with [Claude Code](https://claude.com/claude-code)