### PR TITLE
fix: institutional.py 补全缺失的 svg_sparkline + svg_radar 导入

### DIFF
--- a/skills/deep-analysis/scripts/lib/report/institutional.py
+++ b/skills/deep-analysis/scripts/lib/report/institutional.py
@@ -28,7 +28,7 @@ from __future__ import annotations
 
 from lib.report.svg_primitives import (
     COLOR_BULL, COLOR_BEAR, COLOR_GOLD, COLOR_CYAN, COLOR_MUTED,
-    svg_gauge, svg_progress_row,
+    svg_gauge, svg_progress_row, svg_sparkline, svg_radar,
 )
 from lib.report.dim_viz import _score_class
 


### PR DESCRIPTION
上游 v3.2.0 重构 assemble_report → lib/report/institutional.py 时遗漏了 svg_sparkline 和 svg_radar 的导入，导致 stage2 报告组装阶段 NameError。

## 变更说明

把导入代码加上

## 变更类型

- [x] Bug 修复
- [ ] 新功能
- [ ] 新的分析维度
- [ ] 文档更新
- [ ] 平台兼容性

## 测试

- [x] 本地跑过至少 1 只 A 股分析
- [x] 报告 HTML 正常打开
- [x] 无 Python import 报错

## 相关 Issue

Closes #
