### PR TITLE
docs: agent_analysis.json 必填字段 schema 完整文档化

### DIFF
--- a/commands/analyze-stock.md
+++ b/commands/analyze-stock.md
@@ -75,27 +75,64 @@ if low_quality_dims:
 
 **4. 写 agent_analysis.json（闭环关键！）**
 
-对关键维度（财报/估值/护城河/行业）写 1-2 句定性评语。如果需要，web search 补充信息。
+对关键维度（财报/估值/护城河/行业）写 1-2 句定性评语（≥20 字，引用具体数字）。如果需要，web search 补充信息。
+
+**⚠️ 必读：agent_analysis.json 完整 schema（缺字段 stage2 会报 schema warning/error）**
+
+| 字段 | 要求 | 触发校验 |
+|---|---|---|
+| `agent_reviewed` | 必须 `true` | ⚠️ 缺 → warning |
+| `dim_commentary` | 覆盖全部 22 维，**每条 ≥20 字**（引用具体数字，禁止空泛） | ⚠️ <20 字 → warning |
+| `panel_insights` | **≥30 字**，评委投票分布 + 多空分歧分析 | ⚠️ <30 字 → warning |
+| `great_divide_override` | punchline(≥10 字) + bull_say_rounds(≥3 条) + bear_say_rounds(≥3 条) | 🔴 缺字段 → error |
+| `narrative_override.core_conclusion` | **≥20 字**综合定论 | ⚠️ <20 字 → warning |
+| `narrative_override.risks` | **≥3 条**风险 | ⚠️ <3 条 → warning |
+| `narrative_override.buy_zones` | **必须含 value/growth/technical/youzi 四个 key**，每个 key 内含 `price`(数值, youzi 可为 0) + `rationale`(≥5 字解释) | 🔴 缺 key → error / ⚠️ 缺子字段 → warning |
+| `qualitative_deep_dive` | 覆盖 3_macro/7_industry/8_materials/9_futures/13_policy/15_events 共 6 维。每维含：`evidence` 数组（≥2 条）、`associations` 跨域因果链（6 维合计 ≥3 条）、`conclusion`（1-2 句） | 🔴 evidence 非 list → error |
+| `data_gap_acknowledged` | dict 格式 `{"dim_key": "已尝试 X 但失败的原因"}`，标记数据采集失败但 agent 已知晓的维度 | 🔴 类型非 dict → error |
 
 把所有 agent 产出写入 `.cache/{ticker}/agent_analysis.json`：
 ```python
 from lib.cache import write_task_output
 write_task_output(ticker, "agent_analysis", {
     "agent_reviewed": True,
-    "dim_commentary": { "0_basic": "...", "1_financials": "...", ... },
-    "panel_insights": "整体评委观察...",
+    "dim_commentary": {
+        "0_basic": "公司全称+成立/上市时间+市值+行业地位，≥20字",
+        "1_financials": "ROE/营收增速/净利率/毛利率/FCF等核心数据+质量判断，≥20字",
+        # ... 覆盖全部 22 维，每条 ≥20 字，引用具体数字
+    },
+    "panel_insights": "评委投票分布(看多X/中性X/看空X)+多空分歧核心逻辑，≥30字",
     "great_divide_override": {
-        "punchline": "冲突金句",
-        "bull_say_rounds": ["R1", "R2", "R3"],
-        "bear_say_rounds": ["R1", "R2", "R3"]
+        "punchline": "多空对决一句话金句，≥10字",
+        "bull_say_rounds": ["R1: 看多论点+引用数字", "R2: ...", "R3: ..."],
+        "bear_say_rounds": ["R1: 看空论点+引用数字", "R2: ...", "R3: ..."]
     },
     "narrative_override": {
-        "core_conclusion": "综合结论",
-        "risks": ["风险1", "风险2", ...],
-        "buy_zones": { ... }
+        "core_conclusion": "综合定论+评分+建仓建议，≥20字",
+        "risks": ["风险1", "风险2", "风险3", ...],  # ≥3条
+        "buy_zones": {
+            "value":     {"price": 140, "rationale": "DCF安全边际>60%，等待极端低估"},
+            "growth":    {"price": 160, "rationale": "PEG<0.1极度低估，当前即可建仓"},
+            "technical": {"price": 180, "rationale": "等待Stage 2突破确认后右侧入场"},
+            "youzi":     {"price": 0, "rationale": "非A股不适用游资打板策略"}
+        }
+    },
+    "qualitative_deep_dive": {
+        "3_macro": {
+            "evidence": [{"source": "...", "url": "...", "finding": "...", "retrieved_at": "2026-04-27"}],
+            "associations": [{"link_to": "7_industry", "chain_id": "macro->industry", "causal_chain": "...", "estimated_impact": "medium"}],
+            "conclusion": "宏观结论1-2句"
+        },
+        # ... 7_industry, 8_materials, 9_futures, 13_policy, 15_events 同上格式
+        # 重要：associations 跨所有 6 维合计 ≥3 条
+    },
+    "data_gap_acknowledged": {
+        "10_valuation.pe_quantile": "Lixinger API 对该港股不支持历史分位查询"
     }
 })
 ```
+
+> 详细说明见 `skills/deep-analysis/SKILL.md` 第 464 行 schema 表，以及 `references/task2.5-qualitative-deep-dive.md` 第 5 节。
 
 ### 第三段 · 生成报告（脚本完成）
 

--- a/skills/deep-analysis/SKILL.md
+++ b/skills/deep-analysis/SKILL.md
@@ -461,6 +461,20 @@ genuine investment analysis. The whole point of this plugin is agent-driven judg
 3. 用 agent 的判断覆盖 panel.json 中的 headline/reasoning/score
 4. **写 `agent_analysis.json`** 到 `.cache/{ticker}/` — 这是闭环的关键！
 
+**agent_analysis.json 必填字段（缺字段 stage2 会 schema warning/error）：**
+
+| 字段 | 要求 | 触发校验 |
+|---|---|---|
+| `agent_reviewed` | 必须 `true` | ⚠️ 缺 → warning |
+| `dim_commentary` | 至少 5 个维度，**每条 ≥20 字**（引用具体数字，禁止空泛） | 🔴 <20 字 → warning |
+| `panel_insights` | **≥30 字**，评委投票分布 + 多空分歧分析 | ⚠️ <30 字 → warning |
+| `great_divide_override` | punchline(≥10 字) + bull_say_rounds(≥3 条) + bear_say_rounds(≥3 条) | 🔴 缺字段 → error |
+| `narrative_override.core_conclusion` | **≥20 字**综合定论 | ⚠️ <20 字 → warning |
+| `narrative_override.risks` | **≥3 条**风险 | ⚠️ <3 条 → warning |
+| `narrative_override.buy_zones` | **必须含 value/growth/technical/youzi 四个 key**，每个 key 内含 `price`(数值) + `rationale`(≥5 字解释) | 🔴 缺 key → error / ⚠️ 缺子字段 → warning |
+| `qualitative_deep_dive` | 覆盖 3_macro/7_industry/8_materials/9_futures/13_policy/15_events 共 6 维。每维含：`evidence` 数组（≥2 条 `{source, url, finding, retrieved_at}`）、`associations` 跨域因果链（**6 维合计 ≥3 条** `{link_to, chain_id, causal_chain, estimated_impact}`）、`conclusion`（1-2 句）。详见 `references/task2.5-qualitative-deep-dive.md` 第 5 节 | 🔴 evidence 非 list → error / ⚠️ associations<3 → warning |
+| `data_gap_acknowledged` | v2.3+ 推荐。dict 格式 `{"dim_key": "已尝试 X 但失败的原因"}`。标记数据采集失败但 agent 已知晓的维度，HTML 报告显示 ⚠️ 橙色徽章而非空白 | 🔴 类型非 dict → error |
+
 #### agent_analysis.json 格式
 
 ```json


### PR DESCRIPTION
  ## Summary

  在 **SKILL.md** 和 **commands/analyze-stock.md** 中同时补充 `agent_analysis.json` 必填字段速查表和执行模板，覆盖 `agent_analysis_validator.py` 全部 12 条校验规则。

  ## 问题背景

  Claude Agent 在执行两段式深度分析时，需在 stage1 和 stage2 之间手动写入 `agent_analysis.json`。但原先两个关键文件中都没有展开具体必需字段和格式约束，导致 Agent 频繁遗漏必填字段（如 buy_zones  四派系 / qualitative_deep_dive 的 evidence 子结构），stage2 反复报 schema warning。

  **Edit**：第一版PR只修复了 SKILL.md（文档），但后来发现 Agent 运行时实际读取的是 commands/analyze-stock.md（执行模板）。如果执行模板不改 ，Agent 仍然看不到 schema 约束。本次编辑为同时更新两处。

  ## 改动内容

  ### SKILL.md（+14 行）
  插入一张 9 行 checklist 表格，覆盖所有 validator 校验点

  ### commands/analyze-stock.md（+46 行 / -9 行）
  - 将简略的 Python 模板 `buy_zones: { ... }` 展开为带 value/growth/technical/youzi 四派系的完整示例
  - 新增 `qualitative_deep_dive` 完整示例（evidence/associations/conclusion 子结构）
  - 新增 `data_gap_acknowledged` 示例
  - 新增 schema 约束速查表（与 SKILL.md 一致）
  - 每个字段标注触发严重度 (error/warning) 和精确阈值

  ## Test plan

  - [x] 用 000333.SZ 全流程测试验证：stage1 → agent 写入 agent_analysis.json → stage2，零 schema warning 通过
  - [x] 用 09992.HK 再次验证 Agent 在新指令下不会遗漏 buy_zones 四派系和 qualitative_deep_dive 字段