### PR TITLE
Fix macOS Python 3.11 report rendering and add no-open-report

### DIFF
--- a/run.py
+++ b/run.py
@@ -281,6 +281,8 @@ def main():
                         help="分析完后用 Cloudflare Tunnel 映射公网链接")
     parser.add_argument("--no-browser", action="store_true",
                         help="不自动打开浏览器")
+    parser.add_argument("--no-open-report", action="store_true",
+                        help="生成报告但不自动打开本地 HTML 或 remote URL")
     parser.add_argument("--port", type=int, default=8976,
                         help="HTTP 服务端口 (默认 8976)")
     parser.add_argument("--force-name", metavar="CODE",
@@ -621,8 +623,14 @@ def main():
         except Exception as _e:
             print(f"⚠️  --output-dir 导出失败（不影响本地报告）: {_e}")
 
+    auto_open_report = (
+        not args.no_open_report
+        and not args.no_browser
+        and os.environ.get("UZI_NO_AUTO_OPEN") != "1"
+    )
+
     # 打开浏览器（本地模式）
-    if env["has_browser"] and not args.no_browser and not args.remote:
+    if env["has_browser"] and auto_open_report and not args.remote:
         import webbrowser
         webbrowser.open(standalone.as_uri())
         print(f"   🌐 已在浏览器中打开")
@@ -643,7 +651,7 @@ def main():
             print(f"按 Ctrl+C 停止服务。\n")
 
             # 如果有浏览器也打开
-            if env["has_browser"] and not args.no_browser:
+            if env["has_browser"] and auto_open_report:
                 import webbrowser
                 webbrowser.open(full_url)
 

--- a/skills/deep-analysis/scripts/lib/report/institutional.py
+++ b/skills/deep-analysis/scripts/lib/report/institutional.py
@@ -606,6 +606,10 @@ def _render_school_lock_banner(syn: dict | None) -> str:
         "I": ("#4338ca", "rgba(99,102,241,0.10)", "🔗", "Serenity · AI 供应链卡脖子/瓶颈猎手"),
     }
     fg, bg, icon, members_hint = THEMES.get(group, ("#374151", "rgba(107,114,128,0.10)", "🎯", ""))
+    members_html = (
+        f'<div style="margin-top:4px;color:#6b7280;font-size:11px">代表评委 · {members_hint}</div>'
+        if members_hint else ""
+    )
 
     return (
         f'<div class="school-lock-banner" style="margin:16px 0;padding:14px 20px;'
@@ -620,7 +624,7 @@ def _render_school_lock_banner(syn: dict | None) -> str:
         f'      本次分析仅由 <strong style="color:{fg}">{group} · {label}</strong> 的评委参与评分 · '
         f'其他流派的评委已 skip · 报告里"评委打分板 / 流派分数 / 多空辩论"均限于该派内.'
         f'    </div>'
-        f'    {f"<div style=\"margin-top:4px;color:#6b7280;font-size:11px\">代表评委 · {members_hint}</div>" if members_hint else ""}'
+        f'    {members_html}'
         f'  </div>'
         f'</div>'
     )
@@ -645,4 +649,3 @@ def _render_institutional_section(raw: dict) -> str:
         _render_catalyst_calendar(d21) +
         _render_competitive_analysis(d22)
     )
-

--- a/skills/deep-analysis/scripts/lib/report/segmental.py
+++ b/skills/deep-analysis/scripts/lib/report/segmental.py
@@ -223,6 +223,7 @@ def _render_segmental_block(ticker: str) -> str:
             cagr_row = '<div class="muted" style="font-size:11px">（agent 未填 3 情景 CAGR）</div>'
 
         note_html = f'<div class="seg-note">💡 {note}</div>' if note else ""
+        metrics_html = f'<div class="seg-metrics-row">{margin_badges}</div>' if margin_badges else ""
 
         segment_cards += (
             f'<div class="seg-card">'
@@ -233,7 +234,7 @@ def _render_segmental_block(ticker: str) -> str:
             f'    <span class="seg-share">{share:.1f}%</span>'
             f'  </div>'
             f'  <div class="seg-rev">{currency} <strong>{rev:,.1f}</strong> 亿</div>'
-            f'  {f"<div class=\"seg-metrics-row\">{margin_badges}</div>" if margin_badges else ""}'
+            f'  {metrics_html}'
             f'  {sparkline_html}'
             f'  <div class="seg-drivers">{drivers_html}</div>'
             f'  {cagr_row}'
@@ -551,5 +552,4 @@ def _svg_segment_projection(segments: list, rev_hist: list, width: int = 420, he
   {legend}
   {end_labels}
 </svg>'''
-
 


### PR DESCRIPTION
## Summary
- Fix Python 3.11 f-string compatibility in report rendering by precomputing nested HTML snippets.
- Add a dedicated `--no-open-report` CLI flag so reports can be generated without automatically opening local or remote report URLs.
- Preserve existing `--no-browser` behavior for browser-based collection.

## Validation
- `python -m py_compile skills/deep-analysis/scripts/lib/report/institutional.py`
- `python -m py_compile skills/deep-analysis/scripts/lib/report/segmental.py`
- `python -m py_compile run.py`
- Previously validated AAPL lite, NVDA medium, MSTR medium, and additional medium reports locally.

## Notes
- Local wrapper experiments under `local-tools/` and `local-state/` are intentionally not included.