### PR TITLE
fix(deep-analysis): 停止把缺失数据当成真实发现（ROE 季度/年度混用 + 5 处静默假值 + 共识分闸门）

### DIFF
--- a/skills/deep-analysis/scripts/fetch_financials.py
+++ b/skills/deep-analysis/scripts/fetch_financials.py
@@ -96,6 +96,15 @@ def _fetch_a_share(ti) -> dict:
             out["revenue_history"] = _row("营业总收入")
             out["net_profit_history"] = _row("归属于母公司所有者的净利润") or _row("净利润")
             out["financial_years"] = [str(c)[:4] for c in period_cols_annual]
+
+            # 并发抓取被限流时接口会回空单元格，_to_float 把它们静默变成 0.0。
+            # 一家公司连续多年营收/净利为 0 是不可能的 → 判定为抓取失败，删掉让兜底与
+            # data_gaps 接管，而不是把 0 当真数据喂给 DCF 和规则引擎。
+            for _hist_key in ("revenue_history", "net_profit_history"):
+                _vals = out.get(_hist_key) or []
+                if _vals and not any(abs(_to_float(v)) > 1e-9 for v in _vals):
+                    out.pop(_hist_key, None)
+                    out.setdefault("_zero_history_dropped", []).append(_hist_key)
     except Exception as e:
         out["_abstract_error"] = str(e)
 
@@ -120,33 +129,42 @@ def _fetch_a_share(ti) -> dict:
                     break
 
             last = df_ind.iloc[-1]
+            # ROE / 净利率 / ROIC 是"期间累计"指标：一季报里它们只含 Q1 一个季度的利润，
+            # 拿去和"ROE ≥ 15%"这类年度门槛比，会把每只股在 Q1/Q2 全部误判为不及格。
+            # 存量指标（流动比率 / 资产负债率）是时点数，仍用最新一期。
+            last_annual = df_annual.iloc[-1] if len(df_annual) else last
+
             # Financial health
             health = {}
-            for src_key, dst_key, unit_div in [
-                ("流动比率", "current_ratio", 1),
-                ("资产负债率(%)", "debt_ratio", 1),
-                ("总资产净利率(%)", "roic", 1),
-                ("销售净利率(%)", "net_margin_pct", 1),
+            for src_key, dst_key, src_row in [
+                ("流动比率", "current_ratio", last),
+                ("资产负债率(%)", "debt_ratio", last),
+                ("总资产净利率(%)", "roic", last_annual),
+                ("销售净利率(%)", "net_margin_pct", last_annual),
             ]:
                 if src_key in df_ind.columns:
-                    v = _to_float(last.get(src_key))
+                    v = _to_float(src_row.get(src_key))
                     if v:
-                        health[dst_key] = v / unit_div
+                        health[dst_key] = v
             if health:
                 out["financial_health"] = health
 
-            # Net margin / ROE 汇总 summary strings
+            # Net margin / ROE 汇总 summary strings（口径 = 最近一个完整年度）
             if "加权净资产收益率(%)" in df_ind.columns:
-                out["roe"] = f"{_to_float(last['加权净资产收益率(%)']):.1f}%"
+                out["roe"] = f"{_to_float(last_annual['加权净资产收益率(%)']):.1f}%"
+                out["roe_mrq"] = f"{_to_float(last['加权净资产收益率(%)']):.1f}%"
             if "销售净利率(%)" in df_ind.columns:
-                out["net_margin"] = f"{_to_float(last['销售净利率(%)']):.1f}%"
+                out["net_margin"] = f"{_to_float(last_annual['销售净利率(%)']):.1f}%"
+            out["financial_period"] = str(last_annual.get(date_col))[:10]
 
             # v3.8.0 · DuPont 杜邦分解 · ROE = 净利率 × 总资产周转率 × 权益乘数
             # 价值派(巴菲特/张磊)看 ROE 的"质量来源"：margin 驱动=高质量 · 纯杠杆驱动=风险
             try:
-                _dp_nm = _to_float(last.get("销售净利率(%)")) if "销售净利率(%)" in df_ind.columns else None
-                _dp_to = _to_float(last.get("总资产周转率(次)")) if "总资产周转率(次)" in df_ind.columns else None
-                _dp_dr = _to_float(last.get("资产负债率(%)")) if "资产负债率(%)" in df_ind.columns else None
+                # 三个因子必须同口径（全部取最近完整年度），否则 Q1 的净利率 × 年化周转率
+                # 会重构出一个既非季度也非年度的假 ROE（洛阳钼业曾因此得到 8.66% vs 真实 26.61%）。
+                _dp_nm = _to_float(last_annual.get("销售净利率(%)")) if "销售净利率(%)" in df_ind.columns else None
+                _dp_to = _to_float(last_annual.get("总资产周转率(次)")) if "总资产周转率(次)" in df_ind.columns else None
+                _dp_dr = _to_float(last_annual.get("资产负债率(%)")) if "资产负债率(%)" in df_ind.columns else None
                 _dp_em = (100.0 / (100.0 - _dp_dr)) if (_dp_dr not in (None, 0) and _dp_dr < 100) else None
                 if _dp_nm is not None and _dp_to is not None and _dp_em is not None:
                     _dp_roe = _dp_nm * _dp_to * _dp_em  # net_margin% × turnover × em → ROE%

--- a/skills/deep-analysis/scripts/fetch_industry.py
+++ b/skills/deep-analysis/scripts/fetch_industry.py
@@ -66,7 +66,7 @@ INDUSTRY_ESTIMATES: dict[str, dict] = {
 
 
 def _best_industry_match(industry: str) -> dict:
-    if not industry:
+    if not industry or industry.strip() in _INDUSTRY_PLACEHOLDERS:
         return {}
     for key, val in INDUSTRY_ESTIMATES.items():
         if key in industry or industry in key or industry[:2] in key:
@@ -74,9 +74,15 @@ def _best_industry_match(industry: str) -> dict:
     return {}
 
 
+# 上游 industry 抓不到时，run_real_test 会把"综合"当占位符传进来。拿占位符去做语义匹配
+# 一定会命中垃圾（洛阳钼业曾因此匹到"废弃资源综合利用业"，行业 PE 34.24 完全无关），
+# 宁可返回空让 agent 知道缺数据，也不要一个假的行业对标。
+_INDUSTRY_PLACEHOLDERS = {"综合", "其他", "未知", "-", "—", "None"}
+
+
 def _cninfo_industry_metrics(industry_name: str) -> dict:
     """Pull industry aggregated PE from cninfo — works on this network."""
-    if not industry_name:
+    if not industry_name or industry_name.strip() in _INDUSTRY_PLACEHOLDERS:
         return {}
     today = datetime.now()
     for i in range(1, 8):

--- a/skills/deep-analysis/scripts/fetch_moat.py
+++ b/skills/deep-analysis/scripts/fetch_moat.py
@@ -139,6 +139,12 @@ def main(ticker: str) -> dict:
         snips = results[key]["snippets"]
         return " ".join(s.get("body", "")[:100] for s in snips[:n])
 
+    # 搜索一条都没命中时，_evaluate 对空文本返回 5 → 四维全 5 分，看起来像"评估过且中等"，
+    # 实际是一次都没评估（洛阳钼业：ddgs DNS 挂掉，护城河 5/5/5/5 却被 Porter 当真实输入）。
+    # 有证据才给分，没证据就明说没评估。
+    _evidence = {k: bool(results[k]["text"].strip()) for k in ("intangible", "switching", "network", "scale")}
+    _scored = any(_evidence.values())
+
     return {
         "ticker": ti.full,
         "data": {
@@ -151,7 +157,14 @@ def main(ticker: str) -> dict:
                 "switching": switching_score,
                 "network": network_score,
                 "scale": scale_score,
-            },
+            } if _scored else {},
+            "scores_available": _scored,
+            "scores_evidence": _evidence,
+            "scores_note": (
+                None if _scored else
+                "⚠️ 未评估：四个维度的 web 检索均无结果（不是「中等护城河」）。"
+                "Porter/BCG 若引用此项将得到无意义结果。"
+            ),
             "rd_summary": _top_body("rd", n=2) or "—",
             "web_search_snippets": {k: v["snippets"] for k, v in results.items()},
             "moat_framework": ["intangible", "switching", "network", "scale", "efficient_scale"],

--- a/skills/deep-analysis/scripts/fetch_sentiment.py
+++ b/skills/deep-analysis/scripts/fetch_sentiment.py
@@ -46,8 +46,10 @@ def main(ticker: str) -> dict:
     negative_kws = ["看空", "下跌", "亏损", "利空", "减仓", "卖出", "割肉", "杀跌"]
     pos = sum(1 for kw in positive_kws if kw in text)
     neg = sum(1 for kw in negative_kws if kw in text)
-    total = pos + neg if (pos + neg) > 0 else 1
-    positive_pct = round(pos / total * 100, 0)
+    # 一条舆情都没抓到 ≠ 市场看空。旧版 pos=neg=0 → positive_pct = 0/1 = 0% → 标签"悲观"，
+    # 把抓取失败伪装成了真实的负面情绪（洛阳钼业：股吧 0 条结果，却被判"悲观"）。
+    has_signal = (pos + neg) > 0
+    positive_pct = round(pos / (pos + neg) * 100, 0) if has_signal else None
 
     # Heat gauge (0-100) based on total platform hits
     total_hits = sum(platform_hit.values())
@@ -90,8 +92,8 @@ def main(ticker: str) -> dict:
         if news_text:
             pos += sum(1 for kw in positive_kws if kw in news_text)
             neg += sum(1 for kw in negative_kws if kw in news_text)
-            total2 = pos + neg if (pos + neg) > 0 else 1
-            positive_pct = round(pos / total2 * 100, 0)
+            has_signal = (pos + neg) > 0
+            positive_pct = round(pos / (pos + neg) * 100, 0) if has_signal else None
         news_hit = news_multi.get("total_hits", 0) or 0
         heat = min(100, heat + news_hit * 2)
     except Exception as _e:
@@ -104,8 +106,12 @@ def main(ticker: str) -> dict:
             "thermometer_value": heat,
             "guba_volume": f"{platform_hit.get('guba', 0)} 条结果",
             "big_v_mentions": f"{big_v_count} 位大V提及" if big_v_count else "—",
-            "positive_pct": f"{positive_pct}%",
-            "sentiment_label": "乐观" if positive_pct > 60 else "悲观" if positive_pct < 40 else "中性",
+            "sentiment_data_available": has_signal,
+            "positive_pct": f"{positive_pct}%" if has_signal else "—",
+            "sentiment_label": (
+                ("乐观" if positive_pct > 60 else "悲观" if positive_pct < 40 else "中性")
+                if has_signal else "⚠️ 数据缺失（未抓到任何舆情，非真实负面）"
+            ),
             "platform_snippets": snippets,
             "platform_hits": platform_hit,
             "total_mentions": total_hits,

--- a/skills/deep-analysis/scripts/lib/data_sources.py
+++ b/skills/deep-analysis/scripts/lib/data_sources.py
@@ -243,6 +243,32 @@ def _fetch_a_share_basic_from_baostock(ti: TickerInfo, *, include_quote: bool = 
     return source
 
 
+def _fetch_a_share_profile_cninfo(code: str) -> dict:
+    """巨潮公司概况 — 行业/主营的兜底源。
+
+    东财 stock_individual_info_em 与雪球 stock_individual_basic_info_xq 在 2026 已持续失效
+    （分别返回 JSONDecodeError 与 KeyError 'data'），而 industry 一旦为空，下游 7 个 fetcher
+    会统统 fallback 成"综合"，再被 cninfo 模糊匹配到完全无关的行业（洛阳钼业曾被匹到
+    "废弃资源综合利用业"，行业 PE 因此全错）。巨潮这条链路仍然可用，作为最后一道兜底。
+    """
+    if ak is None:
+        return {}
+    df = ak.stock_profile_cninfo(symbol=code)
+    if df is None or df.empty:
+        return {}
+    rec = df.to_dict("records")[0]
+    out: dict = {}
+    if rec.get("所属行业"):
+        out["industry"] = str(rec["所属行业"]).strip()
+    if rec.get("A股简称"):
+        out["name"] = str(rec["A股简称"]).strip()
+    if rec.get("公司名称"):
+        out["full_name"] = str(rec["公司名称"]).strip()
+    if rec.get("上市日期"):
+        out["listed_date"] = str(rec["上市日期"]).strip()
+    return out
+
+
 def _ensure_a_share_basic_fields(out: dict, ti: TickerInfo) -> dict:
     """Field-level fallback gate for A-share basic data.
 
@@ -283,6 +309,15 @@ def _ensure_a_share_basic_fields(out: dict, ti: TickerInfo) -> dict:
             _merge_missing_basic_fields(out, _fetch_a_share_name_from_ak_code_name(ti), "field:ak_code_name", fields=("name",))
         except Exception as e:
             out["_field_ak_code_name_err"] = f"{type(e).__name__}: {str(e)[:80]}"
+
+    if out.get("industry") in (None, "", "-"):
+        try:
+            _merge_missing_basic_fields(
+                out, _fetch_a_share_profile_cninfo(ti.code), "field:cninfo_profile",
+                fields=("industry", "name", "full_name", "listed_date"),
+            )
+        except Exception as e:
+            out["_field_cninfo_profile_err"] = f"{type(e).__name__}: {str(e)[:80]}"
 
     if out.get("industry") in (None, "", "-"):
         industry = _known_stock_industry(ti.code)

--- a/skills/deep-analysis/scripts/lib/deep_analysis_methods.py
+++ b/skills/deep-analysis/scripts/lib/deep_analysis_methods.py
@@ -173,7 +173,7 @@ def _ic_risks(features: dict, moat: dict) -> list[dict]:
             "severity": "Medium",
             "mitigant": "等待 PE 回归 40 以下再建仓",
         })
-    if not features.get("fcf_positive", True):
+    if features.get("fcf_known") and not features.get("fcf_positive", True):
         risks.append({
             "risk": "现金流为负",
             "detail": "依赖外部融资",

--- a/skills/deep-analysis/scripts/lib/investor_evaluator.py
+++ b/skills/deep-analysis/scripts/lib/investor_evaluator.py
@@ -383,6 +383,21 @@ def panel_summary(results: dict[str, dict]) -> dict:
     sorted_bear = sorted(active.items(), key=lambda kv: kv[1]["score"])[:5]
 
     n_active = len(active)
+
+    # ── 共识分自检 · "空数据幻觉"闸门 ─────────────────────────────
+    # score=0 且 pass_rules/fail_rules 全空 = 规则引擎拿不到 features 后的默认判负，
+    # 不是对这只股的判断。这类条目一旦占比过高，avg_score 就不再是"评委共识"，
+    # 而是"数据缺失度"的镜像（洛阳钼业：29 个看空里 12 个是这种，共识 23.8 分纯属虚构）。
+    # 宁可标记作废，也不要报一个看起来很权威的假数字。
+    hollow = [
+        k for k, v in active.items()
+        if (v.get("score") or 0) == 0
+        and not v.get("pass_rules")
+        and not v.get("fail_rules")
+    ]
+    hollow_pct = round(len(hollow) / n_active * 100, 0) if n_active else 0
+    consensus_valid = hollow_pct < 20
+
     return {
         "total": len(results),
         "active": n_active,
@@ -397,6 +412,17 @@ def panel_summary(results: dict[str, dict]) -> dict:
         "bearish_pct": round(bearish / n_active * 100, 0) if n_active else 0,
         "top_bulls": [{"id": k, "score": v["score"], "headline": v["headline"]} for k, v in sorted_bull],
         "top_bears": [{"id": k, "score": v["score"], "headline": v["headline"]} for k, v in sorted_bear],
+        # 数据诚实度
+        "hollow_verdicts": len(hollow),
+        "hollow_pct": hollow_pct,
+        "hollow_ids": hollow,
+        "consensus_valid": consensus_valid,
+        "consensus_warning": (
+            None if consensus_valid else
+            f"⛔ 共识分不可采信：{len(hollow)}/{n_active} 位评委（{hollow_pct:.0f}%）是"
+            f"「0 分 + 零条规则」的空数据默认判负，avg_score {avg_score} 反映的是数据缺失度而非投资判断。"
+            f"请补齐数据后重跑，或改用 agent 判断覆盖。"
+        ),
     }
 
 

--- a/skills/deep-analysis/scripts/lib/pipeline/score_fns.py
+++ b/skills/deep-analysis/scripts/lib/pipeline/score_fns.py
@@ -520,9 +520,31 @@ def generate_panel(dims_scored: dict, raw: dict) -> dict:
             "dominant_signal": dominant,
         }
 
+    # ── 空数据幻觉闸门 ──────────────────────────────────────────────
+    # score=0 且 pass/fail 规则全空 = 规则引擎拿不到 features 后的默认判负，不是投资判断。
+    # 占比过高时 panel_consensus 反映的是「数据缺失度」而非「评委共识」，必须自我作废。
+    _active_out = [i for i in investors_out if i.get("signal") != "skip"]
+    _hollow = [
+        i.get("investor_id") for i in _active_out
+        if (i.get("score") or 0) == 0
+        and not i.get("pass_rules") and not i.get("fail_rules")
+    ]
+    _hollow_pct = round(len(_hollow) / len(_active_out) * 100, 0) if _active_out else 0
+    _consensus_valid = _hollow_pct < 20
+
     return {
         "ticker": raw["ticker"],
         "panel_consensus": round(consensus, 1),
+        "consensus_valid": _consensus_valid,
+        "hollow_verdicts": len(_hollow),
+        "hollow_pct": _hollow_pct,
+        "hollow_ids": _hollow,
+        "consensus_warning": (
+            None if _consensus_valid else
+            f"⛔ 共识分不可采信：{len(_hollow)}/{len(_active_out)} 位评委（{_hollow_pct:.0f}%）"
+            f"是「0 分 + 零条规则」的空数据默认判负。panel_consensus "
+            f"{round(consensus, 1)} 反映的是数据缺失度，不是投资判断。"
+        ),
         "vote_distribution": vote_dist,
         "signal_distribution": sig_dist,
         "investors": investors_out,

--- a/skills/deep-analysis/scripts/lib/research_workflow.py
+++ b/skills/deep-analysis/scripts/lib/research_workflow.py
@@ -214,7 +214,7 @@ def _build_risks(features: dict, fin: dict) -> list[dict]:
     if features.get("pe", 0) > 60:
         risks.append({"risk": "估值偏高", "severity": "Medium",
                       "detail": f"PE {features.get('pe', 0):.0f}x 高于市场"})
-    if not features.get("fcf_positive", True):
+    if features.get("fcf_known") and not features.get("fcf_positive", True):
         risks.append({"risk": "自由现金流为负", "severity": "High",
                       "detail": "长期依赖外部融资"})
     if features.get("pct_from_60d_high", 0) < -20:

--- a/skills/deep-analysis/scripts/lib/self_review.py
+++ b/skills/deep-analysis/scripts/lib/self_review.py
@@ -529,6 +529,32 @@ def check_consensus_formula_sanity(ctx: dict) -> list[Issue]:
     return issues
 
 
+def check_panel_hollow_verdicts(ctx: dict) -> list[Issue]:
+    """空数据幻觉闸门 · score=0 且零条规则的评委占比过高时，共识分不可采信。
+
+    洛阳钼业(603993)实例：29 位看空里 12 位是「0 分 + 零 fail_rule」，理由是"非降息周期"
+    "垄断度不够"这类风格模板——它们不是对个股的判断，而是规则引擎拿不到 features 后的
+    默认判负。avg_score 23.8 反映的是数据缺失度，不是投资判断。这类报告一律不许出。
+    """
+    issues = []
+    panel = ctx.get("panel") or {}
+    if panel.get("consensus_valid", True):
+        return issues
+    issues.append(Issue(
+        severity="critical", category="panel", dim="panel",
+        issue=f"共识分建立在空数据之上（{panel.get('hollow_verdicts')} 位评委 0 分且零条规则）",
+        evidence=(
+            f"hollow_pct={panel.get('hollow_pct')}% · panel_consensus={panel.get('panel_consensus')} · "
+            f"ids={', '.join((panel.get('hollow_ids') or [])[:8])}"
+        ),
+        suggested_fix=(
+            "补齐 features 缺口（优先 0_basic.industry / 财报 / 估值）后重跑 stage1，"
+            "或在 agent_analysis.json 里用 agent 判断覆盖 panel。禁止直接引用 panel_consensus。"
+        ),
+    ))
+    return issues
+
+
 def check_panel_insights_rendered(ctx: dict) -> list[Issue]:
     """v2.9.1 · panel_insights 字段必须在报告里渲染（之前被丢掉的 bug）"""
     issues = []
@@ -595,6 +621,7 @@ CHECKS = [
     check_factcheck_redflags,
     # v2.9.1 · 评委汇总一致性检查
     check_consensus_formula_sanity,
+    check_panel_hollow_verdicts,
     check_panel_insights_rendered,
     check_debate_bull_bear_populated,
 ]

--- a/skills/deep-analysis/scripts/lib/stock_features.py
+++ b/skills/deep-analysis/scripts/lib/stock_features.py
@@ -141,7 +141,11 @@ def extract_features(raw: dict, dims: dict) -> dict:
         default=0,
     )
     f["roic"] = _f(health.get("roic"))
-    f["fcf_positive"] = f["fcf_margin"] > 0
+    # 三态：抓不到 FCF ≠ FCF 为负。旧版 _f(None) → 0 → fcf_positive=False，于是 IC Memo 和
+    # 首次覆盖会同时凭空捏造一条 High 级风险"现金流为负·依赖外部融资"。
+    # 现在 fcf_known 为假时，下游风险生成器必须闭嘴。
+    f["fcf_known"] = health.get("fcf_margin") is not None
+    f["fcf_positive"] = (f["fcf_margin"] > 0) if f["fcf_known"] else True
 
     # v3.8.0 · DuPont 杜邦分解 · 暴露给评委/报告 (价值派看 ROE 质量来源)
     _dupont = fin.get("dupont") or {}
@@ -375,11 +379,16 @@ def extract_features(raw: dict, dims: dict) -> dict:
         f["industry_growth"] = 0.0
 
     # market_share: 真实 = 公司市值 / 行业总市值 × 100
-    # 数据源：basic.market_cap (亿) + industry.cninfo_metrics.total_mcap_yi (亿)
+    # 数据源：basic.market_cap + industry.cninfo_metrics.total_mcap_yi (亿)
+    # ⚠️ basic.market_cap 视兜底源不同，可能是「元」(tencent_qt 直出 3.6e11) 也可能是「亿」。
+    # 旧版直接当「亿」用 → 洛阳钼业算出 market_share = 30,429,605,425%，BCG 定位随之全错。
+    # A 股最大市值也不过 ~2 万亿元（2e4 亿），故 > 1e6 一律判定为「元」。
     _cmcap_yi = _f(basic.get("market_cap_yi")) or _f(basic.get("market_cap"))
+    if _cmcap_yi > 1e6:
+        _cmcap_yi = _cmcap_yi / 1e8
     _imcap_yi = _f((industry.get("cninfo_metrics") or {}).get("total_mcap_yi"))
     if _cmcap_yi > 0 and _imcap_yi > 0:
-        f["market_share"] = round(_cmcap_yi / _imcap_yi * 100, 2)
+        f["market_share"] = round(min(_cmcap_yi / _imcap_yi * 100, 100.0), 2)
     else:
         f["market_share"] = 0.0
     # Dividend yield from valuation/basic

--- a/skills/deep-analysis/scripts/run_real_test.py
+++ b/skills/deep-analysis/scripts/run_real_test.py
@@ -601,6 +601,10 @@ def stage1(ticker: str) -> dict:
     skip_n = sd.get("skip", 0)
     active_n = len(panel["investors"]) - skip_n
     print(f"  参与 {active_n} · 跳过 {skip_n} · 看多 {sd['bullish']} · 中性 {sd['neutral']} · 看空 {sd['bearish']}")
+    if not panel.get("consensus_valid", True):
+        print(f"  {panel.get('consensus_warning')}")
+        print(f"     空判评委: {', '.join(panel.get('hollow_ids', [])[:8])}")
+        print(f"     → 先补数据再看结论，或直接用 agent 判断覆盖 panel.json")
 
     features = extract_features(raw, raw.get("dimensions", {}))
 


### PR DESCRIPTION
## TL;DR

采集管线在多处把**「抓取失败」静默转换成一个看起来合理的数值**。这些假值一路流进 DCF、Porter/BCG 和 51 位评委的规则引擎，最终凑出一个很权威的**假结论**。

拿 **洛阳钼业 (603993)** 实测，修复前后：

| | 修复前 | 修复后 | 真实值 |
|---|---|---|---|
| ROE | **9.1%** | 26.6% | 26.61%（2025 年报）|
| 所属行业 | `None` | 有色金属矿采选业 | ✅ |
| 行业对标 | **废弃资源综合利用业**（PE 34.24）| 有色金属矿采选业（PE 19.7）| ✅ |
| 六年营收历史 | **[0, 0, 0, 0, 0, 0]** | [1129.8 … 2066.8] 亿 | ✅ 与年报一致 |
| market_share | **30,429,605,425%** | 19.75% | ✅ |
| 舆情 | **「悲观」** | ⚠️ 数据缺失（非真实负面）| 实际 0 条 |
| 护城河 | **5 / 5 / 5 / 5** | 未评估 | 实际检索无结果 |
| IC Memo 首要风险 | **「现金流为负·依赖外部融资」** | （不再生成）| FCF 字段根本没抓到 |
| **最终结论** | **共识 23.8 分 · 回避** | ⛔ 共识分不可采信 | ROE 26.6%、六年净利 CAGR 54%、PE 五年 12 分位 |

---

## 🔴 影响面最大的一个：ROE 季度/年度口径混用

`fetch_financials.py` 取 `last = df_ind.iloc[-1]` —— **最新一期 = 一季报**，然后把这个 **Q1 的「期间累计」ROE** 拿去和「ROE ≥ 15%」这类**年度**门槛比较。

```python
last = df_ind.iloc[-1]                                        # 2026-03-31（一季报！）
out["roe"] = f"{_to_float(last['加权净资产收益率(%)']):.1f}%"   # 9.1% ← Q1 单季
```

洛钼的实际序列：
```
[..., 11.7 (25Q2), 18.65 (25Q3), 26.61 (25年报), 9.06 (26Q1)]
                                  ↑ 应该取这个      ↑ 实际取了这个
```

**这意味着任何 A 股在 Q1/Q2 被分析时，ROE 都会被腰斩**，巴菲特/格雷厄姆等价值派评委全员误判看空。DuPont 重构同样中招（三个因子跨期混用 → 洛钼算出 8.66%，真实 26.61%）。

**修复**：ROE / 净利率 / ROIC / DuPont 这些**期间累计**指标改取最近完整年度，季度值另存 `roe_mrq`；流动比率 / 资产负债率等**时点**指标仍用最新一期。

---

## 其余修复

**数据层**
- **静默零填充**：并发限流时 `_to_float()` 把空单元格变成 `0.0` → 「一家公司连续六年营收为零」被当真数据喂给 DCF。现在判定为抓取失败并删键，让兜底与 `_data_gaps` 接管。
- **industry 兜底**：东财 `stock_individual_info_em`（JSONDecodeError）与雪球 `stock_individual_basic_info_xq`（KeyError `'data'`）**均已持续失效**。`industry` 一旦为空，下游 7 个 fetcher 全部 fallback 成 `"综合"`，再被语义匹配到「废弃资源综**合**利用业」。新增**巨潮 `stock_profile_cninfo`** 兜底（该链路仍可用，实测返回「有色金属矿采选业」）。
- **禁止占位符参与语义匹配**：`"综合"` 这类占位符不再拿去匹配 CSRC 行业表，宁可返回空。
- **单位错配**：`market_share` 用市值（元）除以行业总市值（亿）→ 304 亿%，BCG 定位随之全错。

**诚实性：缺失 ≠ 负面**
- **FCF 三态化**：`_f(None) → 0 → fcf_positive=False`，于是 IC Memo 与首次覆盖**同时凭空捏造**一条 High 级风险「现金流为负·依赖外部融资」。新增 `fcf_known`，未知时下游风险生成器闭嘴。
- **舆情**：一条都没抓到时 `positive_pct = 0/1 = 0%` → 标签**「悲观」**。抓取失败被伪装成真实负面情绪。
- **护城河**：检索无结果时 `_evaluate("")` 返回 `5` → 四维全 5 分，看起来像「评估过且中等」。

---

## 🚧 共识分闸门（本 PR 的核心）

`score=0` 且 `pass_rules` / `fail_rules` **全空** = 规则引擎拿不到 features 后的**默认判负**，不是投资判断。

洛钼修复前的 29 位看空评委里，有 12 位是这样的：

| 评委 | score | fail_rules | headline |
|---|---|---|---|
| 费雪 | 0 | **[]** | 看空核心：行业不在成长期 |
| 卡拉曼 | 0 | **[]** | 看空核心：无 30% 安全边际 |
| 达里奥 | 0 | **[]** | 看空核心：非降息周期 |

这些「意见」被平均进 `panel_consensus`，产出一个权威的 **23.8 分 · 回避**。

**SKILL.md 里其实早就警告过这个坑**：

> 绝对禁止……让规则引擎对空 features 打分（会产生"没数据的幻觉"，像之前"北部港湾"那次 panel 35.4% 共识其实是空 features 导致的全 fail_msg）

——但缺少**机械拦截**。本 PR 补上：

- `generate_panel` / `panel_summary` 新增 `consensus_valid` / `hollow_pct` / `hollow_ids`
- 空判占比 ≥ 20% → `consensus_valid = false`
- `self_review` 新增 `check_panel_hollow_verdicts`（**critical**，阻止生成 HTML）
- `stage1` 直接打屏警告

洛钼实测：**10/45 位（22%）空判 → 闸门正确触发**。

---

## 测试

```
626 passed / 30 failed / 1 skipped
```
**与本 PR 之前的 upstream HEAD 基线完全一致**（`git stash` 对比验证过）。那 30 项失败是既有问题，与本改动无关。

12 个文件，+193 / −27。所有修改均附中文注释说明「为什么」，并标注了触发该 bug 的实例。