### PR TITLE
fix: MX fallback for ROE/valuation when sina/baidu fail

### DIFF
--- a/skills/deep-analysis/scripts/fetch_financials.py
+++ b/skills/deep-analysis/scripts/fetch_financials.py
@@ -44,6 +44,160 @@ def _to_yi(v) -> float:
     return round(n / 1e8, 2)
 
 
+def _fetch_roe_history_via_mx(code: str, name_hint: str = "") -> dict:
+    """Pull annual weighted ROE series from 东财妙想 when sina indicator fails.
+
+    Returns {"roe_history": [...], "financial_years": [...], "roe": "xx.x%"} or {}.
+    Prefers 年报 rows; drops 一季报/季报 so coverage critical field stays annual-shaped.
+    """
+    try:
+        from lib.mx_api import MXClient
+    except Exception:
+        return {}
+    client = MXClient()
+    if not client.available:
+        return {}
+
+    label = (name_hint or "").strip() or code
+    queries = [
+        f"{label} 近五年加权净资产收益率",
+        f"{code} 近五年加权净资产收益率ROE",
+        f"{code} 历年年报净资产收益率ROE(加权)",
+    ]
+    for q in queries:
+        try:
+            result = client.query(q)
+        except Exception:
+            continue
+        parsed = _parse_mx_roe_series(result)
+        if parsed.get("roe_history"):
+            parsed["_mx_roe_query"] = q
+            return parsed
+    return {}
+
+
+def _parse_mx_roe_series(result: dict) -> dict:
+    """Extract oldest→newest annual ROE% list from an MX SEARCH_DATA payload."""
+    if not isinstance(result, dict) or result.get("error"):
+        return {}
+    data = result.get("data") or {}
+    inner = data.get("data") if isinstance(data.get("data"), dict) else data
+    sr = (inner or {}).get("searchDataResultDTO") or {}
+    dto_list = sr.get("dataTableDTOList") or []
+    if not dto_list:
+        return {}
+
+    dto = dto_list[0] if isinstance(dto_list[0], dict) else {}
+    table = dto.get("rawTable") or dto.get("table") or {}
+    if not isinstance(table, dict):
+        return {}
+    heads = table.get("headName") or []
+    name_map = dto.get("nameMap") or {}
+    if isinstance(name_map, list):
+        name_map = {str(i): v for i, v in enumerate(name_map)}
+
+    series_key = None
+    for key, values in table.items():
+        if key == "headName":
+            continue
+        label = str(name_map.get(key) or name_map.get(str(key)) or key)
+        if "ROE" in label.upper() or "净资产收益率" in label:
+            series_key = key
+            break
+    if series_key is None:
+        # fallback: first non-head numeric list
+        for key, values in table.items():
+            if key != "headName" and isinstance(values, list) and values:
+                series_key = key
+                break
+    if series_key is None:
+        return {}
+
+    values = table.get(series_key) or []
+    pairs: list[tuple[str, float]] = []
+    for i, raw in enumerate(values):
+        head = str(heads[i]) if i < len(heads) else ""
+        # keep 年报 only · skip 一季报/中报/三季报
+        if head and ("季" in head or "中报" in head):
+            continue
+        year = ""
+        for token in (head[:4],):
+            if token.isdigit():
+                year = token
+        if not year and head:
+            import re
+            m = re.search(r"(20\d{2})", head)
+            year = m.group(1) if m else ""
+        val = _to_float(raw)
+        if year and val:
+            pairs.append((year, round(val, 2)))
+
+    if not pairs:
+        return {}
+    # de-dup by year keeping last, then oldest→newest
+    by_year: dict[str, float] = {}
+    for y, v in pairs:
+        by_year[y] = v
+    years = sorted(by_year.keys())[-6:]
+    hist = [by_year[y] for y in years]
+    return {
+        "roe_history": hist,
+        "financial_years": years,
+        "roe": f"{hist[-1]:.1f}%",
+    }
+
+
+def _fetch_financial_health_via_mx(code: str, name_hint: str = "") -> dict:
+    """Pull current_ratio / debt_ratio / roic / net_margin_pct from MX when sina fails."""
+    try:
+        from lib.mx_api import MXClient
+    except Exception:
+        return {}
+    client = MXClient()
+    if not client.available:
+        return {}
+    label = (name_hint or "").strip() or code
+    try:
+        result = client.query(f"{label} 流动比率 资产负债率 总资产净利率 销售净利率")
+    except Exception:
+        return {}
+    if not isinstance(result, dict) or result.get("error"):
+        return {}
+    data = result.get("data") or {}
+    inner = data.get("data") if isinstance(data.get("data"), dict) else data
+    sr = (inner or {}).get("searchDataResultDTO") or {}
+    dto_list = sr.get("dataTableDTOList") or []
+    if not dto_list or not isinstance(dto_list[0], dict):
+        return {}
+    dto = dto_list[0]
+    table = dto.get("table") or dto.get("rawTable") or {}
+    name_map = dto.get("nameMap") or {}
+    heads = [str(h) for h in (table.get("headName") or [])]
+    idx = 0
+    for i, h in enumerate(heads):
+        if "年报" in h and "季" not in h and "中报" not in h:
+            idx = i
+            break
+    health: dict = {}
+    for key, values in table.items():
+        if key == "headName" or not isinstance(values, list) or not values:
+            continue
+        lab = str(name_map.get(key) or name_map.get(str(key)) or key)
+        raw = values[idx] if idx < len(values) else values[0]
+        num = _to_float(raw)
+        if not num:
+            continue
+        if "流动比率" in lab:
+            health["current_ratio"] = num
+        elif "资产负债率" in lab:
+            health["debt_ratio"] = num
+        elif "总资产净利率" in lab or "ROA" in lab:
+            health["roic"] = num
+        elif "销售净利率" in lab or ("净利率" in lab and "总资产" not in lab):
+            health["net_margin_pct"] = num
+    return health
+
+
 def _apply_operating_cash_flow(out: dict, df_cf) -> None:
     """Attach operating cash-flow fields using 亿 units.
 
@@ -169,6 +323,29 @@ def _fetch_a_share(ti) -> dict:
     except Exception as e:
         out["_indicator_error"] = str(e)
 
+    # ─── 2b. MX 兜底 ROE 历史（sina indicator SSL/墙常见）────────────
+    # coverage 公式把 roe_history 当 critical · sina 挂了就锁 67%。
+    # 东财妙想能稳定返回年报 ROE 序列 · 有 MX_APIKEY 时补齐。
+    if not out.get("roe_history"):
+        mx_roe = _fetch_roe_history_via_mx(code, getattr(ti, "raw", "") or "")
+        if mx_roe.get("roe_history"):
+            out["roe_history"] = mx_roe["roe_history"]
+            if mx_roe.get("financial_years") and not out.get("financial_years"):
+                out["financial_years"] = mx_roe["financial_years"]
+            if mx_roe.get("roe") and not out.get("roe"):
+                out["roe"] = mx_roe["roe"]
+            out["_roe_source"] = "mx_api"
+            out.pop("_indicator_error", None)  # 核心字段已补 · 不再把 sina 错当致命
+
+    # ─── 2c. MX 兜底 financial_health（coverage optional 字段）──
+    if not out.get("financial_health"):
+        mx_health = _fetch_financial_health_via_mx(code, ti.raw if hasattr(ti, "raw") else "")
+        if mx_health:
+            out["financial_health"] = mx_health
+            out["_financial_health_source"] = "mx_api"
+            if not out.get("net_margin") and mx_health.get("net_margin_pct") is not None:
+                out["net_margin"] = f"{mx_health['net_margin_pct']:.1f}%"
+
     # ─── 3. 营收增速 summary
     try:
         rh = out.get("revenue_history") or []
@@ -208,8 +385,7 @@ def _fetch_a_share(ti) -> dict:
         out["_dividend_error"] = str(e)
 
     # v3.4.2 · BaoStock 兜底（Schannel TLS / 网络受限场景）
-    # 当 akshare 链路全挂时（roe/net_margin/revenue_history 都空）· 用 baostock 季报数据补齐.
-    # 触发条件：核心字段缺失 + baostock 可用.
+    # 仅在核心三字段全空时启用（全量季报循环较慢）· roe_history 单缺走上面的 MX 兜底。
     needs_fallback = (
         not out.get("roe") and not out.get("revenue_history") and not out.get("net_margin")
     )

--- a/skills/deep-analysis/scripts/fetch_financials.py
+++ b/skills/deep-analysis/scripts/fetch_financials.py
@@ -38,6 +38,16 @@ def _to_float(v) -> float:
         return 0.0
 
 
+def _to_float_or_none(v) -> float | None:
+    """Parse numeric MX cells · preserve legitimate 0 · return None for missing."""
+    try:
+        if v in (None, "", "--", "-"):
+            return None
+        return float(str(v).replace(",", "").replace("%", ""))
+    except (ValueError, TypeError):
+        return None
+
+
 def _to_yi(v) -> float:
     """Convert raw (often 元) to 亿."""
     n = _to_float(v)
@@ -128,8 +138,8 @@ def _parse_mx_roe_series(result: dict) -> dict:
             import re
             m = re.search(r"(20\d{2})", head)
             year = m.group(1) if m else ""
-        val = _to_float(raw)
-        if year and val:
+        val = _to_float_or_none(raw)
+        if year and val is not None:
             pairs.append((year, round(val, 2)))
 
     if not pairs:
@@ -184,8 +194,8 @@ def _fetch_financial_health_via_mx(code: str, name_hint: str = "") -> dict:
             continue
         lab = str(name_map.get(key) or name_map.get(str(key)) or key)
         raw = values[idx] if idx < len(values) else values[0]
-        num = _to_float(raw)
-        if not num:
+        num = _to_float_or_none(raw)
+        if num is None:
             continue
         if "流动比率" in lab:
             health["current_ratio"] = num

--- a/skills/deep-analysis/scripts/fetch_valuation.py
+++ b/skills/deep-analysis/scripts/fetch_valuation.py
@@ -2,6 +2,8 @@
 
 补全：原方案要求 PE/PB/PEG/PS/EV/EBITDA + DCF + 历史分位 + 行业中枢
 """
+from __future__ import annotations
+
 import json
 import sys
 from typing import Any
@@ -145,6 +147,8 @@ def _fetch_valuation_via_mx(code: str, name_hint: str = "", basic: dict | None =
     label = (name_hint or "").strip() or code
     pe = basic.get("pe_ttm")
     pb = basic.get("pb")
+    used_basic = pe is not None or pb is not None
+    used_mx = False
     pe_q = None
     pe_window = "5 年"
     pb_q = None
@@ -158,6 +162,7 @@ def _fetch_valuation_via_mx(code: str, name_hint: str = "", basic: dict | None =
                     if "市盈率" in str(k) or "PE" in str(k).upper():
                         try:
                             pe = float(str(v).replace("%", "").replace("倍", ""))
+                            used_mx = True
                             break
                         except (TypeError, ValueError):
                             pass
@@ -166,6 +171,7 @@ def _fetch_valuation_via_mx(code: str, name_hint: str = "", basic: dict | None =
                     if "市净率" in str(k) or str(k).upper() == "PB":
                         try:
                             pb = float(str(v).replace("%", "").replace("倍", ""))
+                            used_mx = True
                             break
                         except (TypeError, ValueError):
                             pass
@@ -188,8 +194,17 @@ def _fetch_valuation_via_mx(code: str, name_hint: str = "", basic: dict | None =
                 client.query(f"{code} 市净率PB历史百分位"),
                 "市净率",
             )
+        if pe_q is not None or pb_q is not None:
+            used_mx = True
 
-    out: dict[str, Any] = {"_valuation_source": "basic+mx_api"}
+    if used_basic and used_mx:
+        source = "basic+mx_api"
+    elif used_mx:
+        source = "mx_api"
+    else:
+        source = "basic"
+
+    out: dict[str, Any] = {"_valuation_source": source}
     if pe is not None:
         out["pe"] = str(pe)
     if pb is not None:
@@ -223,10 +238,11 @@ def main_safe(ticker: str) -> dict:
         data.get(k) not in (None, "", "—")
         for k in ("pe", "pb", "pe_quantile", "pb_quantile")
     )
+    src = data.get("_valuation_source") or "basic"
     return {
         "ticker": ti.full,
         "data": data,
-        "source": "basic+mx_api (mini_racer-safe)",
+        "source": f"{src} (mini_racer-safe)",
         "fallback": not filled,
     }
 
@@ -384,7 +400,7 @@ def main(ticker: str) -> dict:
         "ticker": ti.full,
         "data": data,
         "source": "baidu:valuation + cninfo:industry_pe_ratio + simple_dcf"
-        + ("+mx_api" if data.get("_valuation_source") else ""),
+        + ("+mx_api" if "mx_api" in str(data.get("_valuation_source") or "") else ""),
         "fallback": False,
     }
 

--- a/skills/deep-analysis/scripts/fetch_valuation.py
+++ b/skills/deep-analysis/scripts/fetch_valuation.py
@@ -86,6 +86,151 @@ def dcf_sensitivity_matrix(
     }
 
 
+def _mx_latest_pct(result: dict, label_substr: str) -> tuple[float, str] | tuple[None, None]:
+    """Pull newest percentage + window label from MX SEARCH_DATA.
+
+    Returns (value, window) where window is like "3 年" / "5 年" / "历史" inferred
+    from the MX indicator name. Avoids hardcoding "5 年" when MX returns 3Y series.
+    """
+    if not isinstance(result, dict) or result.get("error"):
+        return None, None
+    data = result.get("data") or {}
+    inner = data.get("data") if isinstance(data.get("data"), dict) else data
+    sr = (inner or {}).get("searchDataResultDTO") or {}
+    for dto in sr.get("dataTableDTOList") or []:
+        if not isinstance(dto, dict):
+            continue
+        table = dto.get("table") or dto.get("rawTable") or {}
+        name_map = dto.get("nameMap") or {}
+        if isinstance(name_map, list):
+            name_map = {str(i): v for i, v in enumerate(name_map)}
+        for key, values in table.items():
+            if key == "headName" or not isinstance(values, list) or not values:
+                continue
+            label = str(name_map.get(key) or name_map.get(str(key)) or key)
+            if label_substr not in label:
+                continue
+            for raw in values:
+                try:
+                    v = float(str(raw).replace("%", "").replace("倍", "").replace(",", "").strip())
+                except (TypeError, ValueError):
+                    continue
+                if v >= 0:
+                    window = "历史"
+                    if "5年" in label or "5 年" in label:
+                        window = "5 年"
+                    elif "3年" in label or "3 年" in label:
+                        window = "3 年"
+                    elif "上市以来" in label:
+                        window = "上市以来"
+                    return v, window
+    return None, None
+
+
+def _fetch_valuation_via_mx(code: str, name_hint: str = "", basic: dict | None = None) -> dict:
+    """Safe valuation fill from basic + 东财妙想 · no mini_racer / baidu / cninfo.
+
+    Used when UZI_DISABLE_MINI_RACER=1 or baidu SSL fails. Returns data dict
+    compatible with main()'s data shape (may be partial).
+    """
+    basic = basic or {}
+    try:
+        from lib.mx_api import MXClient
+    except Exception:
+        return {}
+    client = MXClient()
+    if not client.available and not basic:
+        return {}
+
+    label = (name_hint or "").strip() or code
+    pe = basic.get("pe_ttm")
+    pb = basic.get("pb")
+    pe_q = None
+    pe_window = "5 年"
+    pb_q = None
+
+    if client.available:
+        # current PE/PB if basic missing
+        if pe is None or pb is None:
+            snap = client.fetch_snapshot(label) or {}
+            if pe is None:
+                for k, v in snap.items():
+                    if "市盈率" in str(k) or "PE" in str(k).upper():
+                        try:
+                            pe = float(str(v).replace("%", "").replace("倍", ""))
+                            break
+                        except (TypeError, ValueError):
+                            pass
+            if pb is None:
+                for k, v in snap.items():
+                    if "市净率" in str(k) or str(k).upper() == "PB":
+                        try:
+                            pb = float(str(v).replace("%", "").replace("倍", ""))
+                            break
+                        except (TypeError, ValueError):
+                            pass
+
+        pe_q, pe_window = _mx_latest_pct(
+            client.query(f"{label} 市盈率近五年分位数"),
+            "市盈率",
+        )
+        if pe_q is None:
+            pe_q, pe_window = _mx_latest_pct(
+                client.query(f"{code} 市盈率历史百分位"),
+                "市盈率",
+            )
+        pb_q, _pb_window = _mx_latest_pct(
+            client.query(f"{label} 市净率近五年分位数"),
+            "市净率",
+        )
+        if pb_q is None:
+            pb_q, _pb_window = _mx_latest_pct(
+                client.query(f"{code} 市净率PB历史百分位"),
+                "市净率",
+            )
+
+    out: dict[str, Any] = {"_valuation_source": "basic+mx_api"}
+    if pe is not None:
+        out["pe"] = str(pe)
+    if pb is not None:
+        out["pb"] = str(pb)
+    if pe_q is not None:
+        out["pe_quantile"] = f"{pe_window or '5 年'} {pe_q:.0f} 分位"
+    if pb_q is not None:
+        out["pb_quantile"] = f"{pb_q:.0f}%"
+    return out
+
+
+def main_safe(ticker: str) -> dict:
+    """Valuation without mini_racer-prone akshare calls (baidu/cninfo/lg)."""
+    ti = parse_ticker(ticker)
+    basic = {}
+    try:
+        basic = ds.fetch_basic(ti) or {}
+    except Exception:
+        basic = {}
+    data = _fetch_valuation_via_mx(ti.code, getattr(ti, "raw", "") or basic.get("name") or "", basic)
+    # ensure coverage fields aren't left as em-dash placeholders
+    if "pe" not in data:
+        data["pe"] = "—"
+    if "pb" not in data:
+        data["pb"] = "—"
+    if "pe_quantile" not in data:
+        data["pe_quantile"] = "—"
+    if "pb_quantile" not in data:
+        data["pb_quantile"] = "—"
+    filled = any(
+        data.get(k) not in (None, "", "—")
+        for k in ("pe", "pb", "pe_quantile", "pb_quantile")
+    )
+    return {
+        "ticker": ti.full,
+        "data": data,
+        "source": "basic+mx_api (mini_racer-safe)",
+        "fallback": not filled,
+    }
+
+
 def main(ticker: str) -> dict:
     ti = parse_ticker(ticker)
     basic = ds.fetch_basic(ti)
@@ -212,21 +357,34 @@ def main(ticker: str) -> dict:
     iv_total = dcf_result.get("intrinsic_value_total") if isinstance(dcf_result, dict) else None
     dcf_display = f"¥{iv_total / 1e8:.1f}亿" if iv_total else "—"
 
+    data = {
+        "pe": str(cur_pe) if cur_pe is not None else "—",
+        "pb": str(basic.get("pb")) if basic.get("pb") is not None else "—",
+        "pe_quantile": f"5 年 {pe_quantile_val:.0f} 分位" if pe_quantile_val is not None else "—",
+        "pb_quantile": f"{pb_quantile_val:.0f}%" if pb_quantile_val is not None else "—",
+        "industry_pe": str(industry_pe_avg) if industry_pe_avg else "—",
+        "industry_pe_fallback_reason": industry_pe_fallback_reason,
+        "dcf": dcf_display,
+        "pe_history": pe_history,
+        "dcf_simple": dcf_result,
+        "dcf_sensitivity": dcf_sensitivity,
+    }
+
+    # baidu/cninfo SSL 常见失败 · 用 MX/basic 补 pe + 分位（coverage 硬字段）
+    needs_mx = any(data.get(k) in (None, "", "—") for k in ("pe", "pe_quantile", "pb_quantile"))
+    if needs_mx:
+        mx_data = _fetch_valuation_via_mx(ti.code, getattr(ti, "raw", "") or basic.get("name") or "", basic)
+        for k in ("pe", "pb", "pe_quantile", "pb_quantile"):
+            if data.get(k) in (None, "", "—") and mx_data.get(k) not in (None, "", "—"):
+                data[k] = mx_data[k]
+        if mx_data.get("_valuation_source"):
+            data["_valuation_source"] = mx_data["_valuation_source"]
+
     return {
         "ticker": ti.full,
-        "data": {
-            "pe": str(cur_pe) if cur_pe is not None else "—",
-            "pb": str(basic.get("pb")) if basic.get("pb") is not None else "—",
-            "pe_quantile": f"5 年 {pe_quantile_val:.0f} 分位" if pe_quantile_val is not None else "—",
-            "pb_quantile": f"{pb_quantile_val:.0f}%" if pb_quantile_val is not None else "—",
-            "industry_pe": str(industry_pe_avg) if industry_pe_avg else "—",
-            "industry_pe_fallback_reason": industry_pe_fallback_reason,
-            "dcf": dcf_display,
-            "pe_history": pe_history,
-            "dcf_simple": dcf_result,
-            "dcf_sensitivity": dcf_sensitivity,
-        },
-        "source": "baidu:valuation + cninfo:industry_pe_ratio + simple_dcf",
+        "data": data,
+        "source": "baidu:valuation + cninfo:industry_pe_ratio + simple_dcf"
+        + ("+mx_api" if data.get("_valuation_source") else ""),
         "fallback": False,
     }
 

--- a/skills/deep-analysis/scripts/lib/pipeline/collect.py
+++ b/skills/deep-analysis/scripts/lib/pipeline/collect.py
@@ -98,9 +98,29 @@ def collect(ticker: Any, raw_previous: dict | None = None, max_workers: int = 6)
         # v3.0.0 · mini_racer fetcher 必须串行（V8 isolate 非 thread-safe · 跟 legacy 一致）
         legacy_mod = getattr(fetcher, "_legacy_module", "")
         if legacy_mod in _MINI_RACER_LEGACY_MODULES:
-            # v3.3.4 · issue #61 · UZI_DISABLE_MINI_RACER=1 时跳过这 3 个 fetcher
-            # 即使串行化 · macOS Python 3.12/3.13 仍可能 V8 SIGTRAP · 给用户 escape hatch
+            # v3.3.4 · issue #61 · UZI_DISABLE_MINI_RACER=1 时跳过危险 fetcher
+            # valuation 可走 basic+MX 安全路径 · industry/capital_flow 仍 empty
             if os.environ.get("UZI_DISABLE_MINI_RACER") == "1":
+                if dim_key == "10_valuation" or legacy_mod == "fetch_valuation":
+                    try:
+                        from fetch_valuation import main_safe
+                        safe = main_safe(ticker)
+                        data = (safe or {}).get("data") or {}
+                        from .schema import DimResult, Quality
+                        filled = any(
+                            data.get(k) not in (None, "", "—")
+                            for k in ("pe", "pb", "pe_quantile", "pb_quantile")
+                        )
+                        dr = DimResult(
+                            dim_key=dim_key,
+                            data=data,
+                            quality=Quality.PARTIAL if filled else Quality.MISSING,
+                            source=(safe or {}).get("source") or "main_safe",
+                            error=(safe or {}).get("error"),
+                        )
+                        return dim_key, dr.to_dict(), dr.top_level_fields
+                    except Exception as e:
+                        return dim_key, DimResult.error_result(dim_key, f"main_safe: {e}").to_dict(), {}
                 return dim_key, DimResult.empty(dim_key).to_dict(), {}
             with _MINI_RACER_LOCK:
                 result = fetcher.fetch(ticker)

--- a/skills/deep-analysis/scripts/run_real_test.py
+++ b/skills/deep-analysis/scripts/run_real_test.py
@@ -129,6 +129,19 @@ def _disarm_mini_racer_sentinel() -> None:
 def run_fetcher(module_name: str, args: tuple) -> dict:
     # v3.3.4 · issue #61 · 多重保护 mini_racer 崩溃
     if module_name in _MINI_RACER_FETCHERS and _mini_racer_disabled():
+        # valuation 可用 basic+MX 安全路径 · 不必整维跳空（否则 pe/分位 coverage 永久缺口）
+        if module_name == "fetch_valuation":
+            try:
+                from fetch_valuation import main_safe
+                result = main_safe(*args)
+                return result if isinstance(result, dict) else {"data": result}
+            except Exception as e:
+                return {
+                    "data": {"_disabled": "mini_racer skipped; main_safe failed"},
+                    "source": "fetch_valuation (safe-fallback-error)",
+                    "fallback": True,
+                    "error": f"{type(e).__name__}: {e}",
+                }
         return {
             "data": {"_disabled": "mini_racer skipped (env / sentinel)"},
             "source": f"{module_name} (skipped)",

--- a/skills/deep-analysis/scripts/tests/test_mx_coverage_fallback.py
+++ b/skills/deep-analysis/scripts/tests/test_mx_coverage_fallback.py
@@ -58,6 +58,20 @@ def test_parse_mx_roe_series_prefers_annual():
     assert parsed["roe"] == "32.5%"
 
 
+def test_parse_mx_roe_series_keeps_zero():
+    """Legitimate ROE 0 must not be dropped by truthiness checks."""
+    from fetch_financials import _parse_mx_roe_series
+
+    payload = _mx_table(
+        name_map={"roe": "净资产收益率ROE(加权)"},
+        heads=["2025年报", "2024年报", "2023年报"],
+        series={"roe": ["0", "12.5", "--"]},
+    )
+    parsed = _parse_mx_roe_series(payload)
+    assert parsed["roe_history"] == [12.5, 0.0]
+    assert parsed["financial_years"] == ["2024", "2025"]
+
+
 def test_fetch_roe_history_via_mx_uses_client(monkeypatch):
     from fetch_financials import _fetch_roe_history_via_mx
     import fetch_financials as ff
@@ -188,3 +202,114 @@ def test_financial_health_via_mx(monkeypatch):
     assert health["debt_ratio"] == 16.42
     assert health["roic"] == 28.31
     assert health["net_margin_pct"] == 49.58
+
+
+def test_financial_health_via_mx_keeps_zero(monkeypatch):
+    from fetch_financials import _fetch_financial_health_via_mx
+    import lib.mx_api as mx_mod
+
+    class _Client:
+        available = True
+
+        def __init__(self, *a, **k):
+            pass
+
+        def query(self, q):
+            return _mx_table(
+                name_map={
+                    "a": "流动比率",
+                    "b": "资产负债率",
+                    "c": "总资产净利率ROA",
+                    "d": "销售净利率",
+                },
+                heads=["2025年报"],
+                series={
+                    "a": ["0"],
+                    "b": ["--"],
+                    "c": ["0"],
+                    "d": ["12.5"],
+                },
+            )
+
+    monkeypatch.setattr(mx_mod, "MXClient", _Client)
+    health = _fetch_financial_health_via_mx("600519", "贵州茅台")
+    assert health["current_ratio"] == 0.0
+    assert health["roic"] == 0.0
+    assert health["net_margin_pct"] == 12.5
+    assert "debt_ratio" not in health
+
+
+def test_fetch_valuation_via_mx_source_basic_only(monkeypatch):
+    """MX unavailable · only basic fields · source must be basic (not basic+mx_api)."""
+    from fetch_valuation import _fetch_valuation_via_mx
+    import lib.mx_api as mx_mod
+
+    class _Client:
+        available = False
+
+        def __init__(self, *a, **k):
+            pass
+
+    monkeypatch.setattr(mx_mod, "MXClient", _Client)
+    out = _fetch_valuation_via_mx("600519", "贵州茅台", {"pe_ttm": 20.58, "pb": 6.3})
+    assert out["_valuation_source"] == "basic"
+    assert out["pe"] == "20.58"
+    assert out["pb"] == "6.3"
+    assert "pe_quantile" not in out
+
+
+def test_fetch_valuation_via_mx_source_combo(monkeypatch):
+    from fetch_valuation import _fetch_valuation_via_mx
+    import lib.mx_api as mx_mod
+
+    class _Client:
+        available = True
+
+        def __init__(self, *a, **k):
+            pass
+
+        def fetch_snapshot(self, label):
+            return {}
+
+        def query(self, q):
+            if "市盈率" in q:
+                return _mx_table(
+                    name_map={"p": "5年市盈率历史百分位"},
+                    heads=["2026-07-30"],
+                    series={"p": ["33%"]},
+                )
+            return _mx_table(
+                name_map={"p": "5年市净率历史百分位"},
+                heads=["2026-07-30"],
+                series={"p": ["8%"]},
+            )
+
+    monkeypatch.setattr(mx_mod, "MXClient", _Client)
+    out = _fetch_valuation_via_mx("600519", "贵州茅台", {"pe_ttm": 20.58, "pb": 6.3})
+    assert out["_valuation_source"] == "basic+mx_api"
+    assert out["pe"] == "20.58"
+    assert "分位" in out["pe_quantile"]
+    assert out["pb_quantile"] == "8%"
+
+
+def test_fetch_valuation_via_mx_source_mx_only(monkeypatch):
+    from fetch_valuation import _fetch_valuation_via_mx
+    import lib.mx_api as mx_mod
+
+    class _Client:
+        available = True
+
+        def __init__(self, *a, **k):
+            pass
+
+        def fetch_snapshot(self, label):
+            return {"市盈率TTM": "15.2", "市净率": "2.1"}
+
+        def query(self, q):
+            return {"error": "empty"}
+
+    monkeypatch.setattr(mx_mod, "MXClient", _Client)
+    out = _fetch_valuation_via_mx("600519", "贵州茅台", {})
+    assert out["_valuation_source"] == "mx_api"
+    assert out["pe"] == "15.2"
+    assert out["pb"] == "2.1"

--- a/skills/deep-analysis/scripts/tests/test_mx_coverage_fallback.py
+++ b/skills/deep-analysis/scripts/tests/test_mx_coverage_fallback.py
@@ -1,0 +1,190 @@
+"""MX fallback for coverage-critical fields when sina/baidu SSL fails.
+
+Regression for local macOS / restricted-network runs where:
+- stock_financial_analysis_indicator (sina) SSL-fails → roe_history missing
+- stock_zh_valuation_baidu SSL-fails → pe_quantile / pb_quantile missing
+- UZI_DISABLE_MINI_RACER=1 used to skip entire fetch_valuation → pe empty
+  even when basic.pe_ttm was already available.
+
+These tests mock MXClient · no network / no real MX_APIKEY required.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+
+SCRIPTS = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(SCRIPTS))
+
+
+def _mx_table(name_map: dict, heads: list, series: dict) -> dict:
+    """Minimal SEARCH_DATA envelope matching MX live shape."""
+    table = {"headName": heads, **series}
+    return {
+        "success": True,
+        "status": 0,
+        "code": 0,
+        "data": {
+            "status": 0,
+            "code": 0,
+            "data": {
+                "protocolType": "SEARCH_DATA",
+                "searchDataResultDTO": {
+                    "dataTableDTOList": [{
+                        "code": "600519.SH",
+                        "entityName": "贵州茅台(600519.SH)",
+                        "table": table,
+                        "rawTable": table,
+                        "nameMap": name_map,
+                    }],
+                },
+            },
+        },
+    }
+
+
+def test_parse_mx_roe_series_prefers_annual():
+    from fetch_financials import _parse_mx_roe_series
+
+    payload = _mx_table(
+        name_map={"roe": "净资产收益率ROE(加权)"},
+        heads=["2026一季报", "2025年报", "2024年报", "2023年报"],
+        series={"roe": ["10.57", "32.53", "36.02", "34.19"]},
+    )
+    parsed = _parse_mx_roe_series(payload)
+    assert parsed["roe_history"] == [34.19, 36.02, 32.53]
+    assert parsed["financial_years"] == ["2023", "2024", "2025"]
+    assert parsed["roe"] == "32.5%"
+
+
+def test_fetch_roe_history_via_mx_uses_client(monkeypatch):
+    from fetch_financials import _fetch_roe_history_via_mx
+    import fetch_financials as ff
+
+    fake = MagicMock()
+    fake.available = True
+    fake.query.return_value = _mx_table(
+        name_map={"roe": "净资产收益率ROE(加权)"},
+        heads=["2025年报", "2024年报", "2023年报"],
+        series={"roe": ["32.53", "36.02", "34.19"]},
+    )
+
+    class _Client:
+        def __init__(self, *a, **k):
+            pass
+
+        available = True
+        query = fake.query
+
+    monkeypatch.setattr(ff, "_fetch_roe_history_via_mx", ff._fetch_roe_history_via_mx)
+    monkeypatch.setitem(sys.modules, "lib.mx_api", MagicMock(MXClient=_Client))
+
+    # Call through the real helper with patched MXClient import inside function
+    import lib.mx_api as mx_mod
+    monkeypatch.setattr(mx_mod, "MXClient", _Client)
+
+    out = _fetch_roe_history_via_mx("600519", "贵州茅台")
+    assert out.get("roe_history") == [34.19, 36.02, 32.53]
+    assert out.get("_mx_roe_query")
+
+
+def test_mx_latest_pct_reads_window_from_label():
+    from fetch_valuation import _mx_latest_pct
+
+    payload = _mx_table(
+        name_map={"p": "3年市盈率历史百分位"},
+        heads=["2026-07-30", "2026-07-29"],
+        series={"p": ["32.78%", "17.63%"]},
+    )
+    val, window = _mx_latest_pct(payload, "市盈率")
+    assert val == 32.78
+    assert window == "3 年"
+
+
+def test_main_safe_fills_coverage_fields(monkeypatch):
+    from fetch_valuation import main_safe
+    import fetch_valuation as fv
+    import lib.data_sources as ds
+
+    monkeypatch.setattr(ds, "fetch_basic", lambda ti: {"pe_ttm": 20.58, "pb": 6.3, "name": "贵州茅台"})
+
+    def _fake_mx(code, name_hint="", basic=None):
+        return {
+            "_valuation_source": "basic+mx_api",
+            "pe": str((basic or {}).get("pe_ttm")),
+            "pb": str((basic or {}).get("pb")),
+            "pe_quantile": "3 年 33 分位",
+            "pb_quantile": "8%",
+        }
+
+    monkeypatch.setattr(fv, "_fetch_valuation_via_mx", _fake_mx)
+    out = main_safe("600519")
+    assert out["fallback"] is False
+    assert out["data"]["pe"] == "20.58"
+    assert "分位" in out["data"]["pe_quantile"]
+    assert out["data"]["pb_quantile"].endswith("%")
+
+
+def test_disable_miniracer_valuation_uses_main_safe(monkeypatch, tmp_path):
+    """UZI_DISABLE_MINI_RACER=1 · valuation must NOT return empty skip stub."""
+    import run_real_test as rrt
+
+    monkeypatch.setenv("UZI_DISABLE_MINI_RACER", "1")
+    monkeypatch.setattr(rrt, "_MINI_RACER_SENTINEL", tmp_path / "sentinel")
+
+    called = {}
+
+    def _safe(ticker):
+        called["ticker"] = ticker
+        return {
+            "ticker": "600519.SH",
+            "data": {"pe": "20.58", "pe_quantile": "3 年 33 分位", "pb_quantile": "8%"},
+            "source": "basic+mx_api (mini_racer-safe)",
+            "fallback": False,
+        }
+
+    monkeypatch.setattr("fetch_valuation.main_safe", _safe, raising=False)
+    # run_fetcher imports inside function for valuation safe path
+    import fetch_valuation as fv
+    monkeypatch.setattr(fv, "main_safe", _safe)
+
+    result = rrt.run_fetcher("fetch_valuation", ("600519",))
+    assert result.get("fallback") is False
+    assert result.get("data", {}).get("pe") == "20.58"
+    assert "safe" in (result.get("source") or "") or called.get("ticker") == "600519"
+
+
+def test_financial_health_via_mx(monkeypatch):
+    from fetch_financials import _fetch_financial_health_via_mx
+    import lib.mx_api as mx_mod
+
+    class _Client:
+        available = True
+
+        def __init__(self, *a, **k):
+            pass
+
+        def query(self, q):
+            return _mx_table(
+                name_map={
+                    "a": "流动比率",
+                    "b": "资产负债率",
+                    "c": "总资产净利率ROA",
+                    "d": "净利润/营业总收入(销售净利率)",
+                },
+                heads=["2026一季报", "2025年报"],
+                series={
+                    "a": ["7.061", "5.09"],
+                    "b": ["12.12%", "16.42%"],
+                    "c": ["9.027%", "28.31%"],
+                    "d": ["51.47%", "49.58%"],
+                },
+            )
+
+    monkeypatch.setattr(mx_mod, "MXClient", _Client)
+    health = _fetch_financial_health_via_mx("600519", "贵州茅台")
+    assert health["current_ratio"] == 5.09
+    assert health["debt_ratio"] == 16.42
+    assert health["roic"] == 28.31
+    assert health["net_margin_pct"] == 49.58


### PR DESCRIPTION
## Summary
- When sina `stock_financial_analysis_indicator` / baidu valuation SSL-fail, fill coverage-critical fields via 东财妙想 (`MX_APIKEY`): `roe_history`, `financial_health`, PE/PB quantiles.
- When `UZI_DISABLE_MINI_RACER=1`, stop emptying the whole `10_valuation` dim — use `fetch_valuation.main_safe()` (basic + MX) so PE/分位 still populate.
- Wire the same safe path into legacy `run_real_test` and `pipeline.collect`; add mocked unit tests (no network / no real key).

## Why
On restricted networks (observed on macOS), sina/baidu TLS failures leave `roe_history` / PE quantiles empty and lock `coverage_pct` around ~67%. Disabling mini_racer to avoid V8 crashes previously skipped valuation entirely even when `basic.pe_ttm` was already available. With MX configured, coverage-critical fields can stay filled.

## Test plan
- [x] `pytest tests/test_mx_coverage_fallback.py tests/test_v3_3_4_minirackerguard.py -q` (13 passed)
- [ ] With `MX_APIKEY` set: `UZI_DISABLE_MINI_RACER=1 python run.py 600519 --depth lite --no-browser` → `1_financials.roe_history` and `10_valuation.pe*` present; `_integrity.coverage_pct` improves vs pre-patch
- [ ] Without `MX_APIKEY`: behavior remains graceful (no crash; fields may stay empty)
- [ ] Confirm `.env` / secrets are not in this PR


Made with [Cursor](https://cursor.com)