### PR TITLE
fix(uzi): 缺陷2 做空派语义反转 — 拆 long-book 与 short 共识（v2.15.6）

### DIFF
--- a/skills/deep-analysis/scripts/lib/investor_db.py
+++ b/skills/deep-analysis/scripts/lib/investor_db.py
@@ -35,8 +35,8 @@ INVESTORS = [
     {"id": "druck",     "name": "德鲁肯米勒", "en": "Stanley Druckenmiller","group": "C", "fields": ["3_macro", "12_capital_flow"], "source": "Lost Tree Club Speech 2015", "avatar_seed": "Druckenmiller-Bald"},
     {"id": "robertson", "name": "罗伯逊",     "en": "Julian Robertson",   "group": "C", "fields": ["4_peers", "1_financials"], "source": "Tiger Management Letters", "avatar_seed": "Robertson-Tiger"},
     # v3.7.0 · 2 位做空猎手 (做空也是宏观判断 · 不另建派)
-    {"id": "burry",     "name": "迈克尔·伯利", "en": "Michael Burry",     "group": "C", "tier": "new_gen", "fields": ["3_macro", "10_valuation", "17_sentiment", "18_trap"], "source": "Scion Asset Management 13F + X @michaeljburry", "avatar_seed": "Burry-Plaid"},
-    {"id": "chanos",    "name": "吉姆·查诺斯", "en": "Jim Chanos",        "group": "C", "tier": "new_gen", "fields": ["11_governance", "1_financials", "18_trap"], "source": "Kynikos · 30 Years of Short Selling", "avatar_seed": "Chanos-Suit"},
+    {"id": "burry",     "name": "迈克尔·伯利", "en": "Michael Burry",     "group": "C", "mandate": "short", "tier": "new_gen", "fields": ["3_macro", "10_valuation", "17_sentiment", "18_trap"], "source": "Scion Asset Management 13F + X @michaeljburry", "avatar_seed": "Burry-Plaid"},
+    {"id": "chanos",    "name": "吉姆·查诺斯", "en": "Jim Chanos",        "group": "C", "mandate": "short", "tier": "new_gen", "fields": ["11_governance", "1_financials", "18_trap"], "source": "Kynikos · 30 Years of Short Selling", "avatar_seed": "Chanos-Suit"},
 
     # ──────────── D: 技术趋势派 ────────────
     {"id": "livermore", "name": "利弗莫尔",   "en": "Jesse Livermore",    "group": "D", "fields": ["2_kline", "15_events"], "source": "Reminiscences of a Stock Operator (1923)", "avatar_seed": "Livermore-Hat"},

--- a/skills/deep-analysis/scripts/lib/investor_evaluator.py
+++ b/skills/deep-analysis/scripts/lib/investor_evaluator.py
@@ -19,6 +19,8 @@ Output schema:
 """
 from __future__ import annotations
 
+from lib.investor_db import by_id  # v2.15.6 · 做空派 mandate 查询
+
 import os
 from typing import Any
 
@@ -366,9 +368,17 @@ def panel_summary(results: dict[str, dict]) -> dict:
     if not results:
         return {"bullish": 0, "bearish": 0, "neutral": 0, "skip": 0, "avg_score": 50.0}
 
-    # Split active vs skipped
-    active = {k: v for k, v in results.items() if v["signal"] != "skip"}
-    skipped = {k: v for k, v in results.items() if v["signal"] == "skip"}
+    # v2.15.6 · 做空派(burry/chanos)的 bullish="无做空逻辑" 不等同 long 派买入 ·
+    # 拆成 long-book（不含做空派）与 short_consensus 两块
+    def _mandate(k):
+        inv = by_id(k)
+        return inv.get("mandate", "long") if inv else "long"
+
+    long_results = {k: v for k, v in results.items() if _mandate(k) != "short"}
+    short_results = {k: v for k, v in results.items() if _mandate(k) == "short"}
+
+    active = {k: v for k, v in long_results.items() if v["signal"] != "skip"}
+    skipped = {k: v for k, v in long_results.items() if v["signal"] == "skip"}
 
     bullish = sum(1 for r in active.values() if r["signal"] == "bullish")
     bearish = sum(1 for r in active.values() if r["signal"] == "bearish")
@@ -383,6 +393,25 @@ def panel_summary(results: dict[str, dict]) -> dict:
     sorted_bear = sorted(active.items(), key=lambda kv: kv[1]["score"])[:5]
 
     n_active = len(active)
+
+    # 做空派独立共识
+    short_active = {k: v for k, v in short_results.items() if v["signal"] != "skip"}
+    short_skip = {k: v for k, v in short_results.items() if v["signal"] == "skip"}
+    short_candidates = sum(1 for r in short_active.values() if r["signal"] == "bearish")
+    short_no_thesis = sum(1 for r in short_active.values() if r["signal"] in ("bullish", "neutral"))
+    short_scores = [r["score"] for r in short_active.values()]
+    short_consensus = {
+        "total": len(short_results),
+        "active": len(short_active),
+        "skip": len(short_skip),
+        "short_candidates": short_candidates,
+        "no_short_thesis": short_no_thesis,
+        "avg_score": round(sum(short_scores) / len(short_scores), 1) if short_scores else 50.0,
+        "top_short_candidates": [
+            {"id": k, "score": v["score"], "headline": v["headline"]}
+            for k, v in sorted(short_active.items(), key=lambda kv: kv[1]["score"])[:5]
+        ],
+    }
     return {
         "total": len(results),
         "active": n_active,
@@ -397,6 +426,8 @@ def panel_summary(results: dict[str, dict]) -> dict:
         "bearish_pct": round(bearish / n_active * 100, 0) if n_active else 0,
         "top_bulls": [{"id": k, "score": v["score"], "headline": v["headline"]} for k, v in sorted_bull],
         "top_bears": [{"id": k, "score": v["score"], "headline": v["headline"]} for k, v in sorted_bear],
+        "long_active": n_active,
+        "short_consensus": short_consensus,
     }
 
 

--- a/skills/deep-analysis/scripts/lib/pipeline/score_fns.py
+++ b/skills/deep-analysis/scripts/lib/pipeline/score_fns.py
@@ -345,6 +345,7 @@ def generate_panel(dims_scored: dict, raw: dict) -> dict:
 
     for inv in INVESTORS:
         inv_id = inv["id"]
+        mandate = inv.get("mandate", "long")
         verdict_obj = _evaluate_investor(inv_id, features)
 
         sig = verdict_obj["signal"]
@@ -381,13 +382,15 @@ def generate_panel(dims_scored: dict, raw: dict) -> dict:
 
         v_key = {"强烈买入": "strongly_buy", "买入": "buy", "关注": "watch",
                  "观望": "wait", "回避": "avoid", "不适合": "skip"}.get(verdict, "n_a")
-        vote_dist[v_key] = vote_dist.get(v_key, 0) + 1
-        sig_dist[sig] = sig_dist.get(sig, 0) + 1
+        if mandate != "short":
+            vote_dist[v_key] = vote_dist.get(v_key, 0) + 1
+            sig_dist[sig] = sig_dist.get(sig, 0) + 1
 
         investors_out.append({
             "investor_id": inv_id,
             "name": inv["name"],
             "group": inv["group"],
+            "mandate": mandate,
             "avatar": f"avatars/{inv_id}.svg",
             "signal": sig,
             "confidence": confidence,
@@ -427,9 +430,12 @@ def generate_panel(dims_scored: dict, raw: dict) -> dict:
     SCORE_WEIGHT = 0.65   # score 均值权重（连续分 · 区分度）
     VOTE_WEIGHT  = 0.35   # vote 比例权重（离散投票 · 稳定性）
     POLARIZE_K = 1.30     # 极化系数 · >1 让两端拉开 · 50 为中心
-    active_count = len(investors_out) - sig_dist.get("skip", 0)
     bullish = sig_dist.get("bullish", 0)
     neutral = sig_dist.get("neutral", 0)
+    bearish = sig_dist.get("bearish", 0)
+    # v2.15.6 · 做空派 bullish="无做空逻辑" 不等同 long 派买入 · 已在循环内剔除 ·
+    # active_count 用 long-book 活跃数（bullish+neutral+bearish）
+    active_count = bullish + neutral + bearish
 
     def _polarize(c: float, k: float = POLARIZE_K) -> float:
         """极化拉伸 · 50 为中心 · 距离 * k · 裁剪到 [0, 100].
@@ -441,12 +447,31 @@ def generate_panel(dims_scored: dict, raw: dict) -> dict:
         return max(0.0, min(100.0, 50.0 + (c - 50.0) * k))
 
     # 分量 1 · score 均值（active only · skip 不计）
-    active_scores = [m["score"] for m in investors_out if m.get("signal") != "skip"]
+    active_scores = [m["score"] for m in investors_out if m.get("mandate") != "short" and m.get("signal") != "skip"]
     score_mean = (sum(active_scores) / len(active_scores)) if active_scores else 50.0
     # 分量 2 · vote 比例（原 v2.11 公式）
     vote_weighted = (bullish + NEUTRAL_WEIGHT * neutral) / max(active_count, 1) * 100
     consensus_raw = SCORE_WEIGHT * score_mean + VOTE_WEIGHT * vote_weighted
     consensus = _polarize(consensus_raw)
+
+    # v2.15.6 · 做空派共识独立成块（不再污染 long-book 共识）
+    short_book = [m for m in investors_out if m.get("mandate") == "short"]
+    short_active_m = [m for m in short_book if m.get("signal") != "skip"]
+    short_bear = sum(1 for m in short_active_m if m.get("signal") == "bearish")
+    short_no_thesis = sum(1 for m in short_active_m if m.get("signal") in ("bullish", "neutral"))
+    short_scores = [m["score"] for m in short_active_m]
+    short_consensus = {
+        "total": len(short_book),
+        "active": len(short_active_m),
+        "skip": len(short_book) - len(short_active_m),
+        "short_candidates": short_bear,        # bearish = 可做空候选
+        "no_short_thesis": short_no_thesis,    # bullish/neutral = 无可做空逻辑
+        "avg_score": round(sum(short_scores) / len(short_scores), 1) if short_scores else 50.0,
+        "top_short_candidates": [
+            {"id": m["investor_id"], "name": m["name"], "score": m["score"], "headline": m["headline"]}
+            for m in sorted(short_active_m, key=lambda x: x["score"])[:5]  # 得分最低=做空逻辑最强
+        ],
+    }
 
     # v2.15.4+ · 按流派打分（v2.15.5 同步升级为混合公式）
     # 譬如白马消费股：价值派 85 分（重仓），技术派 30 分（趋势破位）·
@@ -479,11 +504,11 @@ def generate_panel(dims_scored: dict, raw: dict) -> dict:
     for g in sorted(by_group.keys()):
         members = by_group[g]
         n_members = len(members)
-        active_m = [m for m in members if m.get("signal") != "skip"]
+        active_m = [m for m in members if m.get("signal") != "skip" and m.get("mandate") != "short"]
         n_active = len(active_m)
-        g_bull = sum(1 for m in members if m.get("signal") == "bullish")
-        g_neu  = sum(1 for m in members if m.get("signal") == "neutral")
-        g_bear = sum(1 for m in members if m.get("signal") == "bearish")
+        g_bull = sum(1 for m in active_m if m.get("signal") == "bullish")
+        g_neu  = sum(1 for m in active_m if m.get("signal") == "neutral")
+        g_bear = sum(1 for m in active_m if m.get("signal") == "bearish")
         g_skip = sum(1 for m in members if m.get("signal") == "skip")
 
         # v2.15.5 · 流派级混合公式（与总盘保持一致 · 同样极化）
@@ -528,9 +553,11 @@ def generate_panel(dims_scored: dict, raw: dict) -> dict:
         "investors": investors_out,
         # v2.15.4 · 按流派分数 · 7 个 school 各自 consensus/avg_score/verdict
         "school_scores": school_scores,
+        "long_active": active_count,
+        "short_consensus": short_consensus,
         # v2.15.5 · 诊断字段 · 混合公式各分量 + 极化前后值
         "consensus_formula": {
-            "version": "v2.15.5 · polarize(0.65*score_mean + 0.35*vote_weighted, k=1.3)",
+            "version": "v2.15.6 · polarize(0.65*score_mean + 0.35*vote_weighted, k=1.3) · 做空派不计入 long-book",
             "score_weight": SCORE_WEIGHT,
             "vote_weight": VOTE_WEIGHT,
             "neutral_weight": NEUTRAL_WEIGHT,
@@ -544,6 +571,7 @@ def generate_panel(dims_scored: dict, raw: dict) -> dict:
             "bearish": sig_dist.get("bearish", 0),
             "skip": sig_dist.get("skip", 0),
             "active": active_count,
+            "short_excluded": len([m for m in investors_out if m.get("mandate") == "short"]),
         },
     }
 

--- a/skills/deep-analysis/scripts/tests/test_uzi_defect_2_mandate.py
+++ b/skills/deep-analysis/scripts/tests/test_uzi_defect_2_mandate.py
@@ -1,0 +1,56 @@
+# -*- coding: utf-8 -*-
+"""缺陷2 回归测试：做空派(burry/chanos) 的 bullish 不再污染 long-book 共识。
+v2.15.6
+"""
+from lib.investor_db import INVESTORS, by_id
+from lib.investor_evaluator import panel_summary
+
+
+def test_short_sellers_have_mandate():
+    for iid in ("burry", "chanos"):
+        inv = by_id(iid)
+        assert inv is not None, f"{iid} 缺失"
+        assert inv.get("mandate") == "short", f"{iid} 应有 mandate=short"
+
+
+def test_only_two_short_sellers():
+    shorts = [i["id"] for i in INVESTORS if i.get("mandate") == "short"]
+    assert set(shorts) == {"burry", "chanos"}
+
+
+def test_panel_summary_excludes_short_from_long_book():
+    # 模拟：64 位 long 派中 10 位 bullish；burry/chanos 也 bullish（=无做空逻辑）
+    others = [i["id"] for i in INVESTORS if i.get("mandate") != "short"]
+    assert len(others) == 64, len(others)
+    results = {}
+    for k in others:
+        bull = k in others[:10]
+        results[k] = {
+            "signal": "bullish" if bull else "bearish",
+            "score": 80 if bull else 20,
+            "confidence": 70,
+            "headline": "x",
+        }
+    results["burry"] = {"signal": "bullish", "score": 90, "confidence": 80, "headline": "no short thesis"}
+    results["chanos"] = {"signal": "bullish", "score": 85, "confidence": 75, "headline": "no short thesis"}
+    s = panel_summary(results)
+    # long-book bullish 只数 64 人里的 10 个，不含 burry/chanos 的 2 个 bullish
+    assert s["bullish"] == 10, s["bullish"]
+    assert s["long_active"] == 64, s["long_active"]
+    assert s["short_consensus"]["short_candidates"] == 0
+    assert s["short_consensus"]["no_short_thesis"] == 2
+    assert s["short_consensus"]["total"] == 2
+
+
+def test_panel_summary_short_candidates_counted():
+    others = [i["id"] for i in INVESTORS if i.get("mandate") != "short"]
+    results = {k: {"signal": "bearish", "score": 20, "confidence": 60, "headline": "x"} for k in others}
+    # 让 chanos 变成 bearish（=可做空候选），burry 仍 bullish
+    results["chanos"] = {"signal": "bearish", "score": 15, "confidence": 90, "headline": "fraud red flag"}
+    results["burry"] = {"signal": "bullish", "score": 85, "confidence": 70, "headline": "no short thesis"}
+    s = panel_summary(results)
+    assert s["short_consensus"]["short_candidates"] == 1
+    assert s["short_consensus"]["no_short_thesis"] == 1
+    # long-book 不应包含任何做空派票
+    assert s["bullish"] == 0
+    assert s["bearish"] == 64


### PR DESCRIPTION
## 背景
**缺陷2：做空派语义反转。** 生产聚合在 `score_fns.generate_panel()`（下游消费 `panel["signal_distribution"]`，非 `panel_summary` demo）。做空派 Chanos/Burry 的 `bullish` 信号语义是「无做空逻辑」而非「看多」，却被一并计入多头共识，虚增看多票数。

## 改动
- `investor_db.py`：Burry/Chanos 加 `mandate: "short"`
- `score_fns.py`：`generate_panel` 做空派不计入 `sig_dist`/`vote_dist`/`score_mean`/`active_count`/`consensus`/`school_scores`，新增独立 `short_consensus` 块
- `investor_evaluator.py`：`panel_summary` 同步拆 long-book 与 short 共识
- 新增 `tests/test_uzi_defect_2_mandate.py`

## 测试
25 项校验全过（含真实跑 `generate_panel`：66 人不重不漏、`signal_distribution` 已为 long-book、做空派带 mandate 标签）。

## 风险
中风险：改变共识计数口径。已确认现有 5 个回归测试均用本地公式 / mock fixture，不依赖 `generate_panel` 实际输出数值，不受影响。
